### PR TITLE
Include time values in reponses for `stats` and `metadata` API calls

### DIFF
--- a/ce/api/metadata.py
+++ b/ce/api/metadata.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm.exc import NoResultFound
 def metadata(sesh, model_id):
     '''Delegate for performing a metadata lookup for one single file
 
-    Multi-paragraph
+    The `metadata` call is intended for the client to retrieve
+    attributes, model information and organizational information. In
+    also includes variable/measured quantity names as well as the time
+    values for which data exists. The `metadata` call uses information
+    from the `modelmeta` database exclusively and does not hit any data
+    files on disk.
 
     Args:
         sesh (sqlalchemy.orm.session.Session): A database Session object

--- a/ce/api/metadata.py
+++ b/ce/api/metadata.py
@@ -1,37 +1,51 @@
-'''
-Query Params
-
-id: Model ID[s] (optional, null means all models)
-
-Returns JSON model metadata:
-
-{
-model_id1:
-    {
-    institute_id: <string>,
-    institution: <string>,
-    model_id: <string>,
-    model_name: <string>,
-    experiment: <string>,
-    variables: [<string:var1>, <string:var2>, ... ],
-    ensemble_member: <string>
-    },
-model_id2:
-    ...
-}
+'''module for requesting metadata for one single file through the API
 '''
 
 from modelmeta import DataFile
 
-def metadata(sesh, model_id=None):
-    '''
-    '''
-    if not model_id:
-        raise NotImplementedError("There will only ever be a single mddb"
-                "Ensemble for the Climate Explorer, but there will be many"
-                "more other things in the database, so we need to discuss what"
-                "'return all models' actually means")
+def metadata(sesh, model_id):
+    '''Delegate for performing a metadata lookup for one single file
 
+    Multi-paragraph
+
+    Args:
+        sesh (sqlalchemy.orm.session.Session): A database Session object
+        model_id (str): Unique id which is a key to the data file requested
+
+    Returns:
+        dict: Empty dictionary if model_id is not found in the database.
+
+        Otherwise returns a single dict with the key of the file's
+        unique_id and the value being a nested dict with keys:
+        'institution', 'model_id', 'model_name', 'experiment',
+        'ensemble_member' (run_name?), and 'variables'.
+
+        'variables' is a nested dict of netcdf variable name, long
+        variable description pars.
+
+        For example::
+
+            {
+                'tmax_monClim_PRISM_historical_run1_198101-201012':
+                {
+                    'institution': 'Pacific Climate Impacts Consortium',
+                    'model_id': 'BCSD+ANUSPLIN300+CCSM4',
+                    'model_name': 'CCSM4 GCM data downscaled to '
+                                  'ANUSPLINE grid using BCSD',
+                    'experiment': 'historical+rcp45',
+                    'ensemble_member': 'r1i1p1',
+                    'variables':
+                    {
+                        'tasmax': 'Maximum daily temperature',
+                        'tasmin': 'Minimum daily temperature',
+                    }
+              }
+         }
+
+    Raises:
+        None?
+
+    '''
     files = sesh.query(DataFile).filter(DataFile.unique_id == model_id).all()
 
     rv = {}

--- a/ce/api/metadata.py
+++ b/ce/api/metadata.py
@@ -59,7 +59,7 @@ def metadata(sesh, model_id):
     except NoResultFound:
         return {}
 
-    vars = {
+    vars_ = {
             dfv.netcdf_variable_name: a.long_name
                 for a, dfv in [
                         (dfv.variable_alias, dfv) for dfv in file_.data_file_variables
@@ -79,7 +79,7 @@ def metadata(sesh, model_id):
             'model_id': model.short_name,
             'model_name': model.long_name,
             'experiment': run.emission.short_name,
-            'variables': vars,
+            'variables': vars_,
             'ensemble_member': run.name,
             'times': times
         }

--- a/ce/api/metadata.py
+++ b/ce/api/metadata.py
@@ -39,9 +39,16 @@ def metadata(sesh, model_id):
                     {
                         'tasmax': 'Maximum daily temperature',
                         'tasmin': 'Minimum daily temperature',
+                    },
+                    'times':
+                    {
+                        0: '1985-01-15T00:00:00Z',
+                        1: '1985-02-15T00:00:00Z',
+                        2: '1985-03-15T00:00:00Z',
+                        3: '1985-04-15T00:00:00Z'
                     }
-              }
-         }
+                }
+            }
 
     Raises:
         None?
@@ -59,6 +66,11 @@ def metadata(sesh, model_id):
                 ]
     }
 
+    times = {
+        time.time_idx: time.timestep.strftime('%Y-%m-%dT%H:%M:%SZ')
+                for time in file_.timeset.times
+    } if file_.timeset else {}
+
     run = file_.run
     model = run.model
     return {
@@ -68,6 +80,7 @@ def metadata(sesh, model_id):
             'model_name': model.long_name,
             'experiment': run.emission.short_name,
             'variables': vars,
-            'ensemble_member': run.name
+            'ensemble_member': run.name,
+            'times': times
         }
     }

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -1,25 +1,4 @@
-'''
-Query Params
-
-id: Model ID
-time: Climatological period (0-17)
-area: WKT of selected area
-variable: Variable requested
-
-Returns JSON statistics for each model:
-
-{
-model_id1:
-    {
-    min: <float>,
-    max: <float>,
-    mean: <float>,
-    median: <float>,
-    stdev: <float>,
-    units: <string>
-    },
-model_id2:
-    ...}
+'''module for requsting summary statistics, averaged across a region
 '''
 
 import numpy as np
@@ -31,7 +10,51 @@ from modelmeta import DataFile, Time
 from ce.api.util import get_array, get_units_from_netcdf_file, mean_datetime
 
 def stats(sesh, id_, time, area, variable):
-    '''
+    '''Request and calculate summary statistics averaged across a region
+
+    For performing regional analysis, one typically wants to summarize
+    statistical information across a region. This call allows one to
+    request either a single timestep (or an average across all
+    timesteps), and averaged across all cells within the given region.
+
+    The stats call may only be called for a single data file and single
+    variable per invocation.
+
+    Args:
+        sesh (sqlalchemy.orm.session.Session): A database Session object
+        id_ (str): Unique id which is a key to the data file requested
+        time (int): Timestep integer (1-17) representing the time of year
+        area (str): WKT polygon of selected area
+        variable (str): Short name of the variable to be returned
+
+    Returns:
+        dict: Empty dictionary if model_id is not found in the database.
+
+        Otherwise, returns a single dict with the key of the file's
+        unique_id and the value consisting of a nested dictionary with
+        the following attributes: 'mean', 'stdev', 'min', 'max',
+        'median', 'ncells', 'units', 'time'.
+
+        For example ::
+
+            {'file0':
+                {
+                    'mean': 303.97227647569446,
+                    'stdev': 8.428096450998078,
+                    'min': 288.71807861328125,
+                    'max': 318.9695739746094,
+                    'median': 301.61065673828125,
+                    'ncells': 72,
+                    'units': 'K',
+                    'time': '1985-06-30T12:00:00Z'
+                }
+            }
+
+    Raises:
+        Exception in several cases:
+
+        1. The file pointed to by `id_` does not exist in the filesystem
+        2. The requested variable does not exist in the given file
     '''
     try:
         df = sesh.query(DataFile).filter(DataFile.unique_id == id_).one()

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timezone
 
 import numpy as np
 import numpy.ma as ma
@@ -74,3 +75,8 @@ def get_array(fname, time, area, variable):
         return ma.masked_array(a.data, mask)
     else:
         return ma.masked_array(a, mask)
+
+def mean_datetime(datetimes):
+    timestamps = [ dt.replace(tzinfo=timezone.utc).timestamp() for dt in datetimes ]
+    mean = np.mean(timestamps)
+    return datetime.fromtimestamp(mean, tz=timezone.utc)

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -380,8 +380,12 @@ def test_stats(populateddb, polygon):
         assert rv['file0'][attr] > 0
         assert type(rv['file0'][attr]) == float
 
-    assert rv['file0']['units']
+    for attr in ('units', 'time'):
+        assert rv['file0'][attr]
+        print(rv['file0'][attr])
+
     assert type(rv['file0']['ncells']) == int
+    assert parse(rv['file0']['time'])
 
 def test_stats_bad_variable(populateddb):
     sesh = populateddb.session

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -349,6 +349,10 @@ def test_metadata(populateddb, unique_id):
                 'experiment', 'variables', 'ensemble_member']:
         assert key in rv[unique_id]
 
+def test_metadata_empty(populateddb):
+    sesh = populateddb.session
+    assert metadata(sesh, None) == {}
+
 @pytest.mark.parametrize(('model'), ('cgcm3', ''))
 def test_multimeta(populateddb, model):
     sesh = populateddb.session

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -340,14 +340,26 @@ def test_lister(populateddb, args, expected):
     rv = lister(sesh, **args)
     assert set(rv) == set(expected)
 
-@pytest.mark.parametrize(('unique_id'), ('file0', 'file1'))
+@pytest.mark.parametrize(('unique_id'), ('file0', 'file4'))
 def test_metadata(populateddb, unique_id):
     sesh = populateddb.session
     rv = metadata(sesh, unique_id)
     assert unique_id in rv
-    for key in ['institution', 'model_id', 'model_name',
-                'experiment', 'variables', 'ensemble_member']:
+    for key in ['institution', 'model_id', 'model_name', 'experiment',
+                'variables', 'ensemble_member', 'times']:
         assert key in rv[unique_id]
+
+    times = rv[unique_id]['times']
+    assert len(times) > 0
+
+    # Are the values converible into times?
+    for val in times.values():
+        assert parse(val)
+
+def test_metadata_no_times(populateddb):
+    sesh = populateddb.session
+    rv = metadata(sesh, 'file1')
+    assert rv['file1']['times'] == {}
 
 def test_metadata_empty(populateddb):
     sesh = populateddb.session

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -1,10 +1,13 @@
 from pkg_resources import resource_filename
+from datetime import timezone
+from datetime import datetime
 
 import pytest
 import numpy as np
 from numpy.ma import MaskedArray
+from dateutil.parser import parse
 
-from ce.api.util import get_array
+from ce.api.util import get_array, mean_datetime
 
 @pytest.mark.parametrize(('fname', 'var'), (
     ('cgcm.nc', 'tasmax'),
@@ -17,3 +20,14 @@ def test_get_array(fname, var):
     assert type(x) == MaskedArray
     assert hasattr(x, 'mask')
     assert np.mean(x) > 0
+
+utc = timezone.utc
+
+@pytest.mark.parametrize(('input_', 'output'), (
+    (['2001-01-01T00:00:00Z'], '2001-01-01T00:00:00Z'),
+    (['2001-01-01T00:00:00Z', '2001-01-04T00:00:00Z'], '2001-01-02T12:00:00Z'),
+    (['2001-01-01T00:00:00Z', '2001-01-04T00:00:00Z', '2001-01-07T00:00:00Z'], '2001-01-04T00:00:00Z'),
+))
+def test_mean_datetime(input_, output):
+    x = [ parse(t).replace(tzinfo=utc) for t in input_ ]
+    assert mean_datetime(x) == parse(output).replace(tzinfo=utc)


### PR DESCRIPTION
Fairly self-explanatory... I have added a 'time' key value pair to the dictionary responses of both the `stats()` call and the `metadata()` call.

The `metadata()` call returns a dict of all available times keyed by their integer index while the `stats()` call returns the actual time value for the time index that the user requested (or the mean of all time values if the user omitted the time index).

The only hangup that I can see with returning a mean time is that the time values aren't necessarily consistent within a file if the file represents monthly, seasonal, *and* annual data. This maybe speaks more to a hazard in the `stats()` specs than anything to do with this PR, though.

In any case, I think it's good to go, but please feel free to review.