### PR TITLE
Bugfix/multi time data

### DIFF
--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -72,7 +72,7 @@ def data(sesh, model, emission, time, area, variable):
     except ValueError:
         raise Exception('time parameter "{}" not convertable to an integer.'.format(time))
 
-    results = sesh.query(Run, DataFile)\
+    results = sesh.query(Run)\
             .join(Model, Emission, DataFile, DataFileVariable, TimeSet)\
             .filter(DataFileVariable.netcdf_variable_name == variable)\
             .filter(Emission.short_name == emission)\
@@ -99,5 +99,5 @@ def data(sesh, model, emission, time, area, variable):
                         getdata(file_, time) for file_ in get_files_from_run_variable(run, variable)
             },
             'units': get_units_from_run_object(run, variable)
-        } for run, data_file in results
+        } for run in results
     }

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -72,25 +72,32 @@ def data(sesh, model, emission, time, area, variable):
     except ValueError:
         raise Exception('time parameter "{}" not convertable to an integer.'.format(time))
 
-    results = sesh.query(Run, Time.timestep)\
-            .join(Model, Emission, DataFile, DataFileVariable, TimeSet, Time)\
+    results = sesh.query(Run, DataFile)\
+            .join(Model, Emission, DataFile, DataFileVariable, TimeSet)\
             .filter(DataFileVariable.netcdf_variable_name == variable)\
             .filter(Emission.short_name == emission)\
             .filter(Model.short_name == model)\
-            .filter(Time.time_idx == time)\
             .filter(TimeSet.multi_year_mean == True).all()
 
     if not results:
         return {}
 
-    def getdata(file_):
-        a = get_array(file_.filename, time, area, variable)
+    def getdata(file_, time_idx):
+        a = get_array(file_.filename, time_idx, area, variable)
         return np.asscalar(np.mean(a))
+
+    def get_timeval(timeset, idx):
+        for time in timeset.times:
+            if time.time_idx == idx:
+                return time.timestep
+        raise Exception('Timeset has not time with index value {}'.format(idx))
 
     return {
         run.name: {
             'data': {
-                timeval.strftime('%Y-%m-%dT%H:%M:%SZ'): getdata(file_) for file_ in get_files_from_run_variable(run, variable) },
+                get_timeval(file_.timeset, time).strftime('%Y-%m-%dT%H:%M:%SZ'):
+                        getdata(file_, time) for file_ in get_files_from_run_variable(run, variable)
+            },
             'units': get_units_from_run_object(run, variable)
-        } for run, timeval in results
+        } for run, data_file in results
     }

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -150,3 +150,54 @@ def test_client(app):
 
 def db(app):
     return SQLAlchemy(app)
+
+@pytest.fixture
+def multitime_db(cleandb):
+    '''A fixture which represents multiple runs where there exist
+       multiple climatological time periods in each run
+    '''
+    dbcopy = cleandb
+    sesh = dbcopy.session
+    ens = Ensemble(name='ce', version=2.0, changes='', description='')
+
+    now = datetime.now()
+
+    rcp45 = Emission(short_name='rcp45')
+    runs = [ Run(name='run{}'.format(i), emission=rcp45) for i in range(3) ]
+    cgcm = Model(short_name='cgcm3', long_name='',
+                 type='GCM', runs=runs, organization='CCCMA')
+
+    files = [ DataFile(filename=resource_filename('ce', 'tests/data/cgcm.nc'),
+                       unique_id='file{}'.format(i), first_1mib_md5sum='xxxx',
+                       x_dim_name='lon', y_dim_name='lat', index_time=now,
+                       run=run) for i, run in enumerate(runs) ]
+
+    tasmax = VariableAlias(long_name='Daily Maximum Temperature',
+                         standard_name='air_temperature', units='degC')
+
+    anuspline_grid = Grid(name='Canada ANUSPLINE', xc_grid_step=0.0833333,
+                          yc_grid_step=0.0833333, xc_origin=-140.958,
+                          yc_origin=41.0417, xc_count=1068, yc_count=510,
+                          xc_units='degrees_east', yc_units='degrees_north',
+                          evenly_spaced_y=True)
+
+    dfvs = [ DataFileVariable(netcdf_variable_name='tasmax', range_min=0,
+                            range_max=50, file=file_,
+                            variable_alias=tasmax, grid=anuspline_grid)
+             for file_ in files]
+
+    times = [
+        Time(time_idx=0, timestep=datetime(1985+y, 1, 15))
+        for y in range(0, 90, 30)
+    ]
+    for file_, t in zip(files, times):
+        ts = TimeSet(calendar='gregorian', start_date=datetime(1971, 1, 1),
+                     end_date=datetime(2099, 12, 31), multi_year_mean=True,
+                     num_times=10, time_resolution='other',
+                     times = [t])
+        ts.files = [file_]
+
+    sesh.add_all(files + dfvs + runs + [anuspline_grid, tasmax, cgcm, rcp45, ens])
+    sesh.commit()
+
+    return dbcopy

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -452,6 +452,14 @@ def test_data_single_variable_file(populateddb, variable):
     rv = data(populateddb.session, 'cgcm3', 'rcp45', 1, None, variable)
     assert len(rv) == 1
 
+def test_data_multiple_times(multitime_db):
+    rv = data(multitime_db.session, 'cgcm3', 'rcp45', 0, None, 'tasmax')
+    print(rv)
+    assert len(rv) > 1
+    for run in rv.values():
+        assert len(run['data']) > 1
+
+
 @pytest.mark.parametrize(('polygon'), test_polygons.values(), ids=list(test_polygons.keys()))
 def test_timeseries(populateddb, polygon):
     sesh = populateddb.session

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -452,9 +452,9 @@ def test_data_single_variable_file(populateddb, variable):
     rv = data(populateddb.session, 'cgcm3', 'rcp45', 1, None, variable)
     assert len(rv) == 1
 
+
 def test_data_multiple_times(multitime_db):
     rv = data(multitime_db.session, 'cgcm3', 'rcp45', 0, None, 'tasmax')
-    print(rv)
     assert len(rv) > 1
     for run in rv.values():
         assert len(run['data']) > 1


### PR DESCRIPTION
Since a single run can have multiple files associated with it, and each different file can potentially have different time values, we need to actually determine the time value by following it out from the file.

Fortunately each `Datafile` object has a `timeset` attribute that points to its set of times, so it's straightforward to use the time_idx parameter to look that up.

I put together a realistic test fixture to test the code, but it would probably be good to try it on real data as well.

Fixes #6