### PR TITLE
Allow 0 as a valid time parameter

### DIFF
--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -58,7 +58,7 @@ def get_array(fname, time, area, variable):
     a = nc.variables[variable]
 
     # FIXME: Assumes 3d data... doesn't support levels
-    if time:
+    if time or time == 0:
         assert 'time' in nc.variables[variable].dimensions
         a = a[time,:,:]
     else:


### PR DESCRIPTION
Old boolean check would return data for all time steps when requesting January resulting in something very close to the annual value.
As long as this doesn't break anything, the fix is very simple.