### PR TITLE
Rewrote mulitmeta API call to only make one DB query.

### DIFF
--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -38,12 +38,10 @@ def multimeta(sesh, ensemble_name='ce', model=''):
 
     q = sesh.query(DataFile.unique_id, Model.organization, Model.short_name,
             Model.long_name, Emission.short_name, Run.name,
-            DataFileVariable.netcdf_variable_name, VariableAlias.long_name,
-            Time.time_idx, Time.timestep)\
+            DataFileVariable.netcdf_variable_name, VariableAlias.long_name)\
             .join(Run).join(Model).join(Emission).join(DataFileVariable)\
             .join(EnsembleDataFileVariables).join(Ensemble)\
-            .join(VariableAlias).join(TimeSet).join(Time)\
-            .filter(Ensemble.name == ensemble_name)
+            .join(VariableAlias).filter(Ensemble.name == ensemble_name)
 
     rv = {}
     results = q.all()
@@ -51,8 +49,7 @@ def multimeta(sesh, ensemble_name='ce', model=''):
     # FIXME: aggregation of the variables can be done in database with the
     # array_agg() function. Change this when SQLAlchemy supports it
     # circa release 1.1
-    for id_, org, model_short, model_long, emission, run, var, long_var,\
-            time_idx, timestep in results:
+    for id_, org, model_short, model_long, emission, run, var, long_var in results:
         if id_ not in rv:
             rv[id_] = {
                 'institution': org,
@@ -61,10 +58,8 @@ def multimeta(sesh, ensemble_name='ce', model=''):
                 'experiment': emission,
                 'variables': {var: long_var},
                 'ensemble_member': run,
-                'times': {time_idx: timestep.strftime('%Y-%m-%dT%H:%M:%SZ')},
             }
         else:
             rv[id_]['variables'][var] = long_var
-            rv[id_]['times'][time_idx] = timestep.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     return rv

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -58,9 +58,9 @@ def multimeta(sesh, ensemble_name='ce', model=''):
                 'institution': org,
                 'model_id': model_short,
                 'model_name': model_long,
-                'experiment': run,
+                'experiment': emission,
                 'variables': {var: long_var},
-                'ensemble_member': emission,
+                'ensemble_member': run,
                 'times': {time_idx: timestep.strftime('%Y-%m-%dT%H:%M:%SZ')},
             }
         else:

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -375,7 +375,7 @@ def test_multimeta(populateddb, model):
     assert 'file0' in rv
     assert rv['file0']['model_id'] == 'cgcm3'
     # times are not included in the multimeta API call
-    assert 'times' in rv['file0']
+    assert 'times' not in rv['file0']
 
 @pytest.mark.parametrize(('polygon'), test_polygons.values(), ids=list(test_polygons.keys()))
 def test_stats(populateddb, polygon):

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -375,7 +375,7 @@ def test_multimeta(populateddb, model):
     assert 'file0' in rv
     assert rv['file0']['model_id'] == 'cgcm3'
     # times are not included in the multimeta API call
-    assert 'times' not in rv['file0']
+    assert 'times' in rv['file0']
 
 @pytest.mark.parametrize(('polygon'), test_polygons.values(), ids=list(test_polygons.keys()))
 def test_stats(populateddb, polygon):

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -374,6 +374,8 @@ def test_multimeta(populateddb, model):
     rv = multimeta.__wrapped__(sesh, model=model) # Multimeta is wrapped for caching. Call the wrapped function
     assert 'file0' in rv
     assert rv['file0']['model_id'] == 'cgcm3'
+    # times are not included in the multimeta API call
+    assert 'times' not in rv['file0']
 
 @pytest.mark.parametrize(('polygon'), test_polygons.values(), ids=list(test_polygons.keys()))
 def test_stats(populateddb, polygon):


### PR DESCRIPTION
Fixes #9 

This change fixes the root of the performance problem for `multimeta` by making a single database query and constructing the response from the resulting rows (instead of making a subsequent query for each file to get the variables).

The one problem with this fix is that it eliminates the "time" key from the metadata dictionaries in the `multimeta` response. We talked about doing this "eventually", but this should not be merged until the front-end has been adapted to work w/o time values up front.

Here are the performance differences running on an sqlite3 database with ~7000 files.

```bash
#On master branch
hiebert@cheetah:~$ time curl -s localhost:8000/api/multimeta > /dev/null

real	8m13.092s
user	0m0.008s
sys	0m0.010s

# On bugfix-9 branch
hiebert@cheetah:~$ time curl -s localhost:8000/api/multimeta > /dev/null

real	0m0.218s
user	0m0.002s
sys	0m0.004s
```

Seems to save about 200-300 ms *per dataset*, which adds up quickly.