### PR TITLE
Adds "ensemble_name" and "timescale" as data request params

### DIFF
--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -3,10 +3,11 @@
 
 import numpy as np
 
-from modelmeta import Run, Time, Emission, Model, TimeSet, DataFile, DataFileVariable
+from modelmeta import Run, Time, Emission, Model, TimeSet, DataFile
+from modelmeta import DataFileVariable, EnsembleDataFileVariables, Ensemble
 from ce.api.util import get_array, get_units_from_run_object, get_files_from_run_variable
 
-def data(sesh, model, emission, time, area, variable):
+def data(sesh, model, emission, time, area, variable, ensemble_name='ce'):
     '''Delegate for performing data lookups across climatological files
 
     Searches the database for all files from a given model and
@@ -74,10 +75,12 @@ def data(sesh, model, emission, time, area, variable):
 
     results = sesh.query(Run)\
             .join(Model, Emission, DataFile, DataFileVariable, TimeSet)\
+            .join(EnsembleDataFileVariables, Ensemble)\
             .filter(DataFileVariable.netcdf_variable_name == variable)\
             .filter(Emission.short_name == emission)\
             .filter(Model.short_name == model)\
-            .filter(TimeSet.multi_year_mean == True).all()
+            .filter(TimeSet.multi_year_mean == True)\
+            .filter(Ensemble.name == ensemble_name).all()
 
     if not results:
         return {}

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -7,7 +7,8 @@ from modelmeta import Run, Time, Emission, Model, TimeSet, DataFile
 from modelmeta import DataFileVariable, EnsembleDataFileVariables, Ensemble
 from ce.api.util import get_array, get_units_from_run_object, get_files_from_run_variable
 
-def data(sesh, model, emission, time, area, variable, ensemble_name='ce'):
+def data(sesh, model, emission, time, area, variable, timescale='other',
+         ensemble_name='ce'):
     '''Delegate for performing data lookups across climatological files
 
     Searches the database for all files from a given model and
@@ -23,6 +24,9 @@ def data(sesh, model, emission, time, area, variable, ensemble_name='ce'):
         time (int): Timestep integer (1-17) representing the time of year
         area (str): WKT polygon of selected area
         variable (str): Short name of the variable to be returned
+        timescale (str): Description of the resolution of time to be
+            returned (e.g. "monthly" or "annual")
+        ensemble_name (str): Some named ensemble
 
     Returns:
         dict:
@@ -79,7 +83,7 @@ def data(sesh, model, emission, time, area, variable, ensemble_name='ce'):
             .filter(DataFileVariable.netcdf_variable_name == variable)\
             .filter(Emission.short_name == emission)\
             .filter(Model.short_name == model)\
-            .filter(TimeSet.multi_year_mean == True)\
+            .filter(TimeSet.time_resolution == timescale)\
             .filter(Ensemble.name == ensemble_name).all()
 
     if not results:

--- a/ce/api/metadata.py
+++ b/ce/api/metadata.py
@@ -45,6 +45,7 @@ def metadata(sesh, model_id):
                         'tasmax': 'Maximum daily temperature',
                         'tasmin': 'Minimum daily temperature',
                     },
+                    'time_resolution': 'monthly',
                     'times':
                     {
                         0: '1985-01-15T00:00:00Z',
@@ -75,6 +76,7 @@ def metadata(sesh, model_id):
         time.time_idx: time.timestep.strftime('%Y-%m-%dT%H:%M:%SZ')
                 for time in file_.timeset.times
     } if file_.timeset else {}
+    timescale = file_.timeset.time_resolution if file_.timeset else 'other'
 
     run = file_.run
     model = run.model
@@ -86,6 +88,7 @@ def metadata(sesh, model_id):
             'experiment': run.emission.short_name,
             'variables': vars_,
             'ensemble_member': run.name,
-            'times': times
+            'times': times,
+            'timescale': timescale
         }
     }

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -211,6 +211,9 @@ def multitime_db(cleandb):
     sesh.add_all(files + dfvs + runs + [anuspline_grid, tasmax, cgcm, rcp45, ens])
     sesh.commit()
 
+    ens.data_file_variables += dfvs
+    sesh.add_all(sesh.dirty)
+
     # Create the three timesets, with just one time step per timeset
     times = [
         Time(time_idx=0, timestep=datetime(1985+y, 1, 15))

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -349,7 +349,7 @@ def test_metadata(populateddb, unique_id):
     rv = metadata(sesh, unique_id)
     assert unique_id in rv
     for key in ['institution', 'model_id', 'model_name', 'experiment',
-                'variables', 'ensemble_member', 'times']:
+                'variables', 'ensemble_member', 'times', 'timescale']:
         assert key in rv[unique_id]
 
     times = rv[unique_id]['times']

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -423,7 +423,8 @@ def test_stats_bad_id(populateddb):
 
 @pytest.mark.parametrize(('time_idx'), (0, 1, 11))
 def test_data(populateddb, time_idx):
-    rv = data(populateddb.session, 'cgcm3', 'rcp45', time_idx, None, 'tasmax')
+    rv = data(populateddb.session, 'cgcm3', 'rcp45', time_idx, None, 'tasmax',
+              timescale="other", ensemble_name="ce")
     assert 'run0' in rv
     assert 'data' in rv['run0']
     for val in rv['run0']['data'].values():


### PR DESCRIPTION
As mentioned in #15 , the `data` API call should filter out ensembles that are not a part of the application configuration. Additionally, it's possible for datasets to be presented in different time resolutions. For example, one might want to present downscaled climate model output as climatologies (e.g. 17 time steps or time_resolution='other') or as an annual timeseries (e.g. 150 or so timesteps). To do this, one must be able to specify the time_resolution when requesting data.

This PR adds both of those parameters to the `data` request and uses them to filter the available datasets from the model metadata database.