### PR TITLE
Remove flask.cache.memoize from multimeta call

### DIFF
--- a/ce/__init__.py
+++ b/ce/__init__.py
@@ -2,16 +2,13 @@ import os
 
 from flask import Flask
 from flask.ext.cors import CORS
-from flask.ext.cache import Cache
 
-cache = Cache(config={'CACHE_TYPE': 'simple'})
 
 from ce.views import add_routes
 
 def get_app():
     app = Flask(__name__)
     CORS(app)
-    cache.init_app(app)
     app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(
         'MDDB_DSN', 'postgresql://httpd_meta@monsoon.pcic.uvic.ca/pcic_meta')
     add_routes(app)

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -4,9 +4,7 @@
 from modelmeta import *
 
 from ce.api.metadata import metadata
-from ce import cache
 
-@cache.memoize(timeout=86400)
 def multimeta(sesh, ensemble_name='ce', model=''):
     '''
     Args

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -371,7 +371,7 @@ def test_metadata_empty(populateddb):
 @pytest.mark.parametrize(('model'), ('cgcm3', ''))
 def test_multimeta(populateddb, model):
     sesh = populateddb.session
-    rv = multimeta.__wrapped__(sesh, model=model) # Multimeta is wrapped for caching. Call the wrapped function
+    rv = multimeta(sesh, model=model) # Multimeta is wrapped for caching. Call the wrapped function
     assert 'file0' in rv
     assert rv['file0']['model_id'] == 'cgcm3'
     # times are not included in the multimeta API call

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Flask
 Flask-SQLAlchemy
 Flask-Cors
-Flask-Cache
 modelmeta
 shapely
 numpy


### PR DESCRIPTION
Flask.cache.memoize does not appear to using optional function argument as part of the cache key. Results in returning old data for a new request containing different arguments. Since #17, this isn't really an issue any more and we should cache at higher level.