### PR TITLE
Adds an attribute check for automatic cache miss

### DIFF
--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -69,7 +69,7 @@ class memoize_mask(object):
 
         nc, wkt = args
         # If we have no key, automatic cache miss
-        if (not hasattr(nc, model_id)):
+        if (not hasattr(nc, 'model_id')):
             log.debug('Cache MISS (attribute \'model_id\' not found)')
             return self.func(*args)
 

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -67,8 +67,14 @@ class memoize_mask(object):
 
     def __call__(self, *args):
 
+        nc, wkt = args
+        # If we have no key, automatic cache miss
+        if (not hasattr(nc, model_id)):
+            log.debug('Cache MISS (attribute \'model_id\' not found)')
+            return self.func(*args)
+
         # Set key to model_id and wkt polygon
-        key = (args[0].model_id, args[1])
+        key = (nc.model_id, wkt)
         log.debug('Checking cache for key {}'.format(key))
 
         with cache_lock:


### PR DESCRIPTION
Memoizing the grid mask in `geo.py` depends on having a hashable key and
the choice of that key affects performance. The 'model_id' netcdf
attribute is a decent choice for a key component, however we shouldn't
necessarily assume that it exists in the file. If a file does *not* have
the model_id attribute, this patch assures an automatic cache miss,
which prevents the code from failing altogether.

We still should follow through with issue #11 at some point (which will
obsolete this patch).