### PR TITLE
Adds 'timescale' attribute to the multimeta call

### DIFF
--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -49,10 +49,10 @@ def multimeta(sesh, ensemble_name='ce', model=''):
     q = sesh.query(mm.DataFile.unique_id, mm.Model.organization,
             mm.Model.short_name, mm.Model.long_name, mm.Emission.short_name,
             mm.Run.name, mm.DataFileVariable.netcdf_variable_name,
-            mm.VariableAlias.long_name)\
+            mm.VariableAlias.long_name, mm.TimeSet.time_resolution)\
             .join(mm.Run).join(mm.Model).join(mm.Emission)\
             .join(mm.DataFileVariable).join(mm.EnsembleDataFileVariables)\
-            .join(mm.Ensemble).join(mm.VariableAlias)\
+            .join(mm.Ensemble).join(mm.VariableAlias).join(mm.TimeSet)\
             .filter(mm.Ensemble.name == ensemble_name)
 
     if model:
@@ -64,7 +64,8 @@ def multimeta(sesh, ensemble_name='ce', model=''):
     # FIXME: aggregation of the variables can be done in database with the
     # array_agg() function. Change this when SQLAlchemy supports it
     # circa release 1.1
-    for id_, org, model_short, model_long, emission, run, var, long_var in results:
+    for id_, org, model_short, model_long, emission, run, var, long_var, \
+            timescale in results:
         if id_ not in rv:
             rv[id_] = {
                 'institution': org,
@@ -73,6 +74,7 @@ def multimeta(sesh, ensemble_name='ce', model=''):
                 'experiment': emission,
                 'variables': {var: long_var},
                 'ensemble_member': run,
+                'timescale': timescale
             }
         else:
             rv[id_]['variables'][var] = long_var

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -69,6 +69,7 @@ def test_multimeta(populateddb, model):
     assert 'file0' in rv
     assert rv['file0']['model_id'] == 'cgcm3'
     # times are not included in the multimeta API call
+    assert 'timescale' in rv['file0']
     assert 'times' not in rv['file0']
 
 def test_stats(populateddb, polygon):


### PR DESCRIPTION
Performance implications are minimal; just one extra attribute per unique_id returned.