### PR TITLE
Adds a more descriptive 400 error message

### DIFF
--- a/ce/api/__init__.py
+++ b/ce/api/__init__.py
@@ -57,8 +57,12 @@ def call(session, request_type):
     required_params = set(get_required_args(func)).difference(['sesh'])
     provided_params = set(request.args.keys())
     optional_params = set(get_keyword_args(func))
-    if required_params.difference(provided_params):
-        return Response("Missing query params", status=400)
+    missing = required_params.difference(provided_params)
+    if missing:
+        return Response("Missing query param{}: {}".format(
+                's' if len(missing) > 1 else '',
+                ', '.join(missing)),
+                status=400)
 
     # FIXME: Sanitize input
     args = { key: request.args.get(key) for key in required_params }

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -23,6 +23,22 @@ def test_api_endpoints_are_callable(test_client, cleandb, endpoint, query_params
     response = test_client.get(url, query_string=query_params)
     assert response.status_code == 200
 
+def test_missing_query_param(test_client, cleandb):
+    url = 'api/metadata'
+    response = test_client.get(url)
+    assert response.status_code == 400
+    assert response.data.decode(response.charset) == "Missing query param: model_id"
+
+def test_missing_query_params(test_client, cleandb):
+    url = '/api/data'
+    response = test_client.get(url)
+    assert response.status_code == 400
+    content = response.data.decode(response.charset)
+    assert "Missing query params:" in content
+    # Ensure that the response *tells* you what's wrong!
+    for param in ('model', 'emission', 'time', 'area', 'variable'):
+        assert param in content
+
 def test_models(populateddb):
     sesh = populateddb.session
     rv = models(sesh, 'ce')


### PR DESCRIPTION
API requests that are missing required query parameters error out
with an HTTP 400 error. The message has been entirely unhelpful:
"Missing query parameters". This commit adds the names of the
missing query parameters to the error message so the user has some path
forward.
