### PR TITLE
Add instructions for installing and using generate_climos

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ it is worth installing only its dependencies. There's a custom `requirements.txt
 (venv) $ pip install -i https://pypi.pacificclimate.org/simple/ -r dp/requirements.txt
 ```
 
+See bash script `process-climo-means.sh` for an example of using this script.
+
 ### Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ git push --follow-tags
   ```
 ## Data file preparation
 
-Input data files can be created from CMIP5 compliant input using the `generate_climos.py` script.
+Input data files can be created from CMIP5 compliant input using the script `dp/generate_climos.py`.
 
 This script:
 
@@ -113,9 +113,42 @@ All output files contain PCIC standard metadata attributes appropriate to climat
 For information on PCIC metadata standards, see
 see https://pcic.uvic.ca/confluence/display/CSG/PCIC+metadata+standard+for+downscaled+data+and+hydrology+modelling+data 
 
+### Installation
+
+Clone the repo onto the target machine.
+
+If installing on a PCIC compute node, you must load the environment modules that data prep depends on
+_before_ installing the Python modules.
+
+```bash
+$ module load netcdf-bin
+$ module load cdo-bin
+```
+
+Python installation should be done in a virtual environment. We recommend a Python3 virtual env, created and activated
+as follows:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+(venv) $
+```
+
+The data prep component (currently just the script `dp/generate_climos.py`) does _not_ depend the CE backend (`ce`).
+Given the effort and time required to install the CE backend, when only the data prep component is required
+it is worth installing only its dependencies. There's a custom `requirements.txt` in `dp` for just this purpose.
+
+```bash
+(venv) $ pip install -U pip setuptools wheel
+(venv) $ pip install -i https://pypi.pacificclimate.org/simple/ -r dp/requirements.txt
+```
+
 ### Usage
 
 ```bash
+# Dry run
+python generate_climos.py --dry-run -o outdir files...
+
 # Use defaults:
 python generate_climos.py -o outdir files...
 

--- a/dp/process-climo-means.sh
+++ b/dp/process-climo-means.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# process a model output file into climatological means
+# - copy input file to local temp
+# - process it with generate_climos.py
+# - copy results from local temp to permanent location
+# - delete copy of input file
+#
+# arguments:
+# $1: unique id for logfile so that this script can be run in several independent processes. Easy: Pass in $$.
+# $2: path to file to be processed
+#
+# typical usage:
+# $ find /input/file/root/ -name "*.nc" -size +1 -print0 | xargs -0 -L 1 ./process-climo-means.sh $$
+
+cp $2 $TMPDIR/
+infile=$TMPDIR/$(basename $2)
+logfile=/storage/data/projects/comp_support/climate_exporer_data_prep/climatological_means/log_$1.txt
+python generate_climos.py --split-vars -o $TMPDIR/output/ $infile >>$logfile 2>&1
+rsync $TMPDIR/output/*.nc /storage/data/projects/comp_support/climate_exporer_data_prep/climatological_means/
+rm $infile
+

--- a/dp/requirements.txt
+++ b/dp/requirements.txt
@@ -1,0 +1,4 @@
+# requirements for data prep (dp) component alone
+python-dateutil
+cdo
+nchelpers


### PR DESCRIPTION
`generate_climos` will typically be used stand-alone on a compute node. It's nice to have installation instructions; installing `climate-explorer-backend` is not a useful option here.

This update also contains an example bash script (actually used) for the standard process of: copy input to temp, run script, copy output to permanent storage.