### PR TITLE
Fix test for annual climo bound end date

### DIFF
--- a/dp/tests/test_create_climo_files.py
+++ b/dp/tests/test_create_climo_files.py
@@ -212,7 +212,7 @@ def test_time_and_climo_bounds_vars(input_and_climo_files, t_start, t_end):
             assert (t.year, t.month, t.day) == (climo_year, 7, 2)
             cb = next(climo_bnds)
             assert cb[0] == d2n(t_start)
-            assert cb[1] == d2n(t_end + relativedelta(days=1))
+            assert cb[1] == d2n(datetime(t_end.year+1, 1, 1))
 
 
 @mark.parametrize('input_and_climo_files, convert_longitudes', [


### PR DESCRIPTION
Noticed an error after I merged master to another branch. Not sure how I missed this, since it tests exactly the code modified to fix #34 :(.

It doesn't help that Travis only runs the main backend tests, and not those for extras (this stuff). But the note in `.travis.yml` explains the problem, and it has no easy fix. Bah.