### PR TITLE
Replace rasterio's rasterize() with mask()

### DIFF
--- a/ce/__init__.py
+++ b/ce/__init__.py
@@ -11,5 +11,6 @@ def get_app():
     CORS(app)
     app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(
         'MDDB_DSN', 'postgresql://httpd_meta@monsoon.pcic.uvic.ca/pcic_meta')
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     add_routes(app)
     return app

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -131,8 +131,8 @@ def polygonToMask(nc, fname, poly, variable):
     # Fill_Value, scale_factor, or add_offset
     var = nc.variables[variable]
     the_array.mask = the_array==the_array.fill_value
-    scale_factor = var.scale_factor if hasattr(var, 'scale_factor') else 1.0
-    add_offset = var.add_offset if hasattr(var, 'add_offset') else 0.0
+    scale_factor = getattr(var, 'scale_factor', 1.0)
+    add_offset = getattr(var, 'add_offset', 0.0)
 
     the_array = the_array * scale_factor + add_offset
     return the_array

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -125,7 +125,7 @@ def polygonToMask(nc, fname, poly, variable):
             raise Exception("Unable to determine projection parameters for GDAL "
                             "dataset {}".format(dst_name))
 
-        the_array, _ = rio_mask(raster, [mapping(poly)], crop=False)
+        the_array, _ = rio_mask(raster, [mapping(poly)], crop=False, all_touched=True)
 
     # Weirdly rasterio's mask operation sets, but doesn't respect the
     # Fill_Value, scale_factor, or add_offset

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -108,11 +108,12 @@ class memoize_mask(object):
             self.misses = 0
 
 @memoize_mask
-def wktToMask(nc, fname, wkt, variable):
+def wkt_to_masked_array(nc, fname, wkt, variable):
     poly = loads(wkt)
-    return polygonToMask(nc, fname, poly, variable)
+    return polygon_to_masked_array(nc, fname, poly, variable)
 
-def polygonToMask(nc, fname, poly, variable):
+
+def polygon_to_masked_array(nc, fname, poly, variable):
 
     nclons = nc.variables['lon'][:]
     if np.any(nclons > 180):

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -129,9 +129,10 @@ def polygonToMask(nc, fname, poly, variable):
 
     # Weirdly rasterio's mask operation sets, but doesn't respect the
     # Fill_Value, scale_factor, or add_offset
+    var = nc.variables[variable]
     the_array.mask = the_array==the_array.fill_value
-    scale_factor = nc.variables[variable].scale_factor
-    add_offset = nc.variables[variable].add_offset
+    scale_factor = var.scale_factor if hasattr(var, 'scale_factor') else 1.0
+    add_offset = var.add_offset if hasattr(var, 'add_offset') else 0.0
 
     the_array = the_array * scale_factor + add_offset
     return the_array

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -74,7 +74,7 @@ def get_array(nc, fname, time, area, variable):
     else:
         a = a[:,:,:]
 
-    return a
+    return ma.masked_array(a)
 
 def mean_datetime(datetimes):
     timestamps = [

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -79,6 +79,8 @@ def get_array(nc, fname, time, area, variable):
     else:
         mask = False
 
+    # FIXME: This could possibly compare a projected polygon mask and an
+    # unprojected raw array
     return ma.masked_array(a, mask)
 
 def mean_datetime(datetimes):

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -7,7 +7,7 @@ import numpy.ma as ma
 from netCDF4 import Dataset
 import modelmeta as mm
 
-from ce.api.geo import wktToMask
+from ce.api.geo import wkt_to_masked_array
 
 def get_files_from_run_variable(run, variable):
     return [file_ for file_ in run.files if variable in
@@ -53,6 +53,7 @@ def open_nc(fname):
     finally:
         nc.close()
 
+
 def get_array(nc, fname, time, area, variable):
 
     if variable not in nc.variables:
@@ -63,10 +64,6 @@ def get_array(nc, fname, time, area, variable):
 
     a = nc.variables[variable]
 
-    if area:
-        # Mask out data that isn't inside the input polygon
-        a = wktToMask(nc, fname, area, variable)
-
     # FIXME: Assumes 3d data... doesn't support levels
     if time or time == 0:
         assert 'time' in nc.variables[variable].dimensions
@@ -74,7 +71,13 @@ def get_array(nc, fname, time, area, variable):
     else:
         a = a[:,:,:]
 
-    return ma.masked_array(a)
+    if area:
+        # Mask out data that isn't inside the input polygon
+        a = wkt_to_masked_array(nc, fname, area, variable)
+    else:
+        a = ma.masked_array(a)
+
+    return a
 
 def mean_datetime(datetimes):
     timestamps = [

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -63,6 +63,10 @@ def get_array(nc, fname, time, area, variable):
 
     a = nc.variables[variable]
 
+    if area:
+        # Mask out data that isn't inside the input polygon
+        a = wktToMask(nc, fname, area, variable)
+
     # FIXME: Assumes 3d data... doesn't support levels
     if time or time == 0:
         assert 'time' in nc.variables[variable].dimensions
@@ -70,18 +74,7 @@ def get_array(nc, fname, time, area, variable):
     else:
         a = a[:,:,:]
 
-    if area:
-        # Mask out data that isn't inside the input polygon
-        mask = wktToMask(nc, fname, area, variable)
-
-        # Extend the mask into the time dimension (if it exists)
-        mask = np.repeat(mask, a.size / mask.size).reshape(a.shape)
-    else:
-        mask = False
-
-    # FIXME: This could possibly compare a projected polygon mask and an
-    # unprojected raw array
-    return ma.masked_array(a, mask)
+    return a
 
 def mean_datetime(datetimes):
     timestamps = [

--- a/ce/tests/test_geo.py
+++ b/ce/tests/test_geo.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 
-from ce.api.geo import wktToMask, polygonToMask
+from ce.api.geo import wkt_to_masked_array, polygon_to_masked_array
 from shapely.wkt import loads
 from shapely.geos import ReadingError
 
@@ -12,7 +12,7 @@ test_polygons = [
 ]
 
 def test_cache(netcdf_file):
-    f = wktToMask
+    f = wkt_to_masked_array
     var = 'tasmax'
     netcdf_file, fname = netcdf_file
     f.cache_clear()
@@ -34,7 +34,7 @@ def test_clip_speed(ncobject, polygon):
     except ReadingError:
         pytest.skip("Invalid polygon, so speed test is irrellevant")
     t0 = time.time()
-    polygonToMask(ncobject, fname, poly, 'tasmax')
+    polygon_to_masked_array(ncobject, fname, poly, 'tasmax')
     t = time.time() - t0
     # Ensure that we can clip our largest polygons in under 100ms
     assert t < .1

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -36,7 +36,7 @@ def test_get_array(request, nctuple, polygon):
     x = get_array(nc, fname, 0, polygon, var)
     t = time() - t0
     print(t)
-    assert t < 0.04
+    assert t < 0.1
     assert type(x) == MaskedArray
     assert hasattr(x, 'mask')
     assert np.mean(x) > 0 or np.all(x.mask)


### PR DESCRIPTION
Fixes #53, fixes #39.

A core operation in the ``climate-explorer-backend`` is take a subset of a climate raster and clip it by a polygon, computing statistics for a specific region. We delegate these spatial operations to the ``rasterio`` library (which in turn uses GDAL for the file I/O).

Previously, we used ``rasterio``'s `rasterize()` method, which "burns" a polygon into a raster. We would then take the mask raster from that operation and union it with the climate raster's existing land/sea mask.

This raised problems, however. The climate raster was an object directly from GDAL and was appropriately projected. whereas the mask output from ``rasterize()`` was essentially just a raw array. It was possible for one array to be flipped vertically, (for example of the array indices started in the upper left hand corner rather than the lower left hand corner) and for the two masks to disagree with each other. Badness ensued.

This changes the code to use ``rasterio``'s `mask()` function (which is *possibly* new since we wrote this code?) which essentially does the same thing, but more directly. No need to manually mangle/union the masks ourselves (so theorettically less room for error).
