### PR TITLE
Slice area-masked array by time index

### DIFF
--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -69,9 +69,19 @@ def stats(sesh, id_, time, area, variable):
         results dict will be missing the 'units' and 'time' keys.
 
     Raises:
-        None?
+        Exception: If `time` parameter cannot be converted to an integer
 
     '''
+    # Validate arguments
+    if time:
+        try:
+            time = int(time)
+        except ValueError:
+            raise Exception('time parameter "{}" not convertable to an integer.'
+                            .format(time))
+    else:
+        time = None
+
     try:
         df = sesh.query(DataFile).filter(DataFile.unique_id == id_).one()
         fname = df.filename

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -64,19 +64,34 @@ def get_array(nc, fname, time, area, variable):
 
     a = nc.variables[variable]
 
-    # FIXME: Assumes 3d data... doesn't support levels
-    if time or time == 0:
-        assert 'time' in nc.variables[variable].dimensions
-        a = a[time,:,:]
-    else:
-        a = a[:,:,:]
-
     if area:
         # Mask out data that isn't inside the input polygon
         a = wkt_to_masked_array(nc, fname, area, variable)
+        a = time_slice_array(a, time, nc, fname, variable)
     else:
+        a = time_slice_array(a, time, nc, fname, variable)
         a = ma.masked_array(a)
 
+    return a
+
+# FIXME: Assumes 3d data... doesn't support levels
+#Reduces a 3-dimensional array to a two-dimensional array by
+#returning the timeidxth slice, IFF time is defined and time
+#is a dimension in the netCDF. Otherwise return array unchanged.
+def time_slice_array(a, timeidx, nc, fname, variable):
+    if timeidx or timeidx == 0:
+        if 'time' not in nc.variables[variable].dimensions:
+            raise Exception(
+                "File {} does not have a time dimension".format(fname)
+                )
+        if not isinstance(timeidx, int): #times passed by URL may be strings
+            try:
+                timeidx = int(timeidx)
+            except ValueError:
+                raise Exception(
+                    "{} is not a valid time index".format(timeidx)
+                    )
+        a = a[timeidx,:,:]
     return a
 
 def mean_datetime(datetimes):

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -84,13 +84,6 @@ def time_slice_array(a, timeidx, nc, fname, variable):
             raise Exception(
                 "File {} does not have a time dimension".format(fname)
                 )
-        if not isinstance(timeidx, int): #times passed by URL may be strings
-            try:
-                timeidx = int(timeidx)
-            except ValueError:
-                raise Exception(
-                    "{} is not a valid time index".format(timeidx)
-                    )
         a = a[timeidx,:,:]
     return a
 

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -258,6 +258,21 @@ def test_timeseries(populateddb, polygon, unique_id, var):
         assert type(val) == float
     assert rv['units'] == 'K'
 
+#verifies that different months or seasons of an annual timeseries
+#have different values
+@pytest.mark.parametrize('unique_id,var', [
+    ('tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230', 'tasmax'),
+    ('tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230', 'tasmin'),
+    ('tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230', 'tasmax'),
+    ('tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230', 'tasmin')])
+def test_timeseries_annual_variation(populateddb, unique_id, var):
+    sesh = populateddb.session
+    poly = """POLYGON((-265 65,-265 74,-276 74,-276 65,-265 65))"""
+    rv = timeseries(sesh, unique_id, poly, var)
+    values = set([])
+    for val in rv['data'].values():
+        assert val not in values
+        values.add(val)
 
 @pytest.mark.parametrize(('unique_id'), (None, '', 'does-not-exist'))
 def test_timeseries_bad_id(populateddb, unique_id):


### PR DESCRIPTION
The issues in #65 (stats and timeseries API results not varying over the course of the year) seem to have been caused by `util.get_array()` returning data for all time indexes at once in a 3D array [time:lat:lon] when passed an area. Then `numpy.mean()` would calculate the average of the _entire_ array - all four or twelve time indexes, resulting in a "timeseries" of twelve/4 identical values, each of which was the mean of the entire year instead of a single month / season. When no area was passed, a 2D array [lat:lon] would be returned.

I remain uncertain, however, because this seems to have been working at some point in the past - at least in one specific docker container whose functionality I cannot duplicate (even by downloading and running the same image from docker hub) - and there's no code change that would explain why it stopped working. Makes me suspicious that something else is going on.

So I would definitely appreciate eyes on this fix.