### PR TITLE
Enable filtering of stats by time resolution - Resolves #61

### DIFF
--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -5,7 +5,7 @@ from ce.api.stats import stats
 from ce.api.util import search_for_unique_ids
 
 def multistats(sesh, ensemble_name='ce', model='', emission='', time=0,
-               area=None, variable=''):
+               area=None, variable='', timescale=''):
     '''Request and calculate statistics for multiple models or scenarios
 
     There are some cases for which one may want to get a set of
@@ -65,7 +65,7 @@ def multistats(sesh, ensemble_name='ce', model='', emission='', time=0,
     '''
 
     ids = search_for_unique_ids(sesh, ensemble_name, model, emission, variable,
-                                time)
+                                time, timescale)
     return {
         id_: stats(sesh, id_, time, area, variable)[id_]
         for id_ in ids

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -88,7 +88,7 @@ def mean_datetime(datetimes):
     return datetime.fromtimestamp(mean, tz=timezone.utc)
 
 def search_for_unique_ids(sesh, ensemble_name='ce', model='', emission='',
-                          variable='', time=0):
+                          variable='', time=0, timescale=''):
     query = sesh.query(mm.DataFile.unique_id)\
             .distinct(mm.DataFile.unique_id)\
             .join(mm.DataFileVariable, mm.EnsembleDataFileVariables, mm.Ensemble,
@@ -102,5 +102,8 @@ def search_for_unique_ids(sesh, ensemble_name='ce', model='', emission='',
 
     if emission:
         query = query.filter(mm.Emission.short_name == emission)
+
+    if timescale:
+        query = query.filter(mm.TimeSet.time_resolution == timescale)
 
     return ( r[0] for r in query.all() )

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -141,7 +141,9 @@ def test_stats(populateddb, polygon, unique_id, var_name):
     ({'variable': 'tasmax'},
      ('CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc', 'file2')),
     ({'variable': 'tasmax', 'model': 'BNU-ESM'},
-     ['tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230'])
+     ['tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230']),
+    ({'variable': 'tasmax', 'timescale': 'seasonal'},
+     ['tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230'])
 ))
 def test_multistats(populateddb, filters, keys):
     sesh = populateddb.session


### PR DESCRIPTION
Addresses #61.

Travis tests are failing due to the recent update of [Shapely](https://pypi.python.org/pypi/Shapely) from version 1.5 to 1.6. The update changed the location of `ReadingError`, which is used in [test_geo.py](https://github.com/pacificclimate/climate-explorer-backend/blob/master/ce/tests/test_geo.py). PR https://github.com/pacificclimate/climate-explorer-backend/pull/68 fixes that issues and should be merged first.