### PR TITLE
Update location of ReadingError

### DIFF
--- a/ce/tests/test_geo.py
+++ b/ce/tests/test_geo.py
@@ -4,7 +4,7 @@ import pytest
 
 from ce.api.geo import wkt_to_masked_array, polygon_to_masked_array
 from shapely.wkt import loads
-from shapely.geos import ReadingError
+from shapely.errors import ReadingError
 
 test_polygons = [
     'POLYGON ((-125 50, -116 50, -116 60, -125 60, -125 50))',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask
 Flask-SQLAlchemy
 Flask-Cors
 modelmeta
-shapely
+shapely>=1.6
 numpy
 netcdf4
 nchelpers

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'Flask-Cors',
         'Flask-Cache',
         'modelmeta',
-        'shapely',
+        'shapely>=1.6',
         'numpy',
         'netcdf4',
         'python-dateutil',


### PR DESCRIPTION
Shapely's update from version 1.5 to version 1.6 on August 20th included consolidating all the package's errors in one file. One of the tests in `test_geo.py` references `shapely.ReadingError` and needs to be updated with the new error location.