### PR TITLE
Upgrade rasterio to new release candidate (from alpha)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,10 @@ before_install:
   - export PATH=$GDALINST/bin:$PATH
   - export LD_LIBRARY_PATH=$GDALINST/lib:$LD_LIBRARY_PATH
   - export GDAL_MINOR_VERSION=$(echo $GDALVERSION | sed -e "s/\\.[0-9]\+$//")
-  - "pip install --global-option=build_ext --global-option='-I$GDALINST/include' --global-option='-L$GDALINST/lib' --global-option='-R$GDALINST/lib' rasterio GDAL==$GDAL_MINOR_VERSION"
+  - "pip install --global-option=build_ext --global-option='-I$GDALINST/include' --global-option='-L$GDALINST/lib' --global-option='-R$GDALINST/lib' GDAL==$GDAL_MINOR_VERSION"
 install:
   - pip install -I pytest>=3.0.0
+  - pip install -r requirements.txt .
   - pip install -i https://pypi.pacificclimate.org/simple/ .
 script:
   - py.test -v ce/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - libnetcdf-dev
 env:
   global:
+    - PIP_INDEX_URL=https://pypi.pacificclimate.org/simple
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
     - GDALVERSION="2.2.1"
@@ -35,7 +36,7 @@ before_install:
 install:
   - pip install -I pytest>=3.0.0
   - pip install -r requirements.txt .
-  - pip install -i https://pypi.pacificclimate.org/simple/ .
+  - pip install .
 script:
   - py.test -v ce/tests
 

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 import modelmeta
 from modelmeta import *
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from netCDF4 import Dataset
 
 from ce import get_app

--- a/ce/tests/test_db.py
+++ b/ce/tests/test_db.py
@@ -1,5 +1,5 @@
 import pytest
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from modelmeta import *
 
 def test_can_query_db(cleandb):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ shapely>=1.6
 numpy
 netcdf4==1.3
 GDAL==2.2
-rasterio==1.0b2
+rasterio==1.0rc3
 # For testing
 pytest
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Cors
 modelmeta
 shapely>=1.6
 numpy
-netcdf4
+netcdf4==1.3
 GDAL==2.2
 rasterio==1.0b2
 # For testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ shapely>=1.6
 numpy
 netcdf4
 GDAL==2.2
-rasterio==1.0a12
+rasterio==1.0b2
 # For testing
 pytest
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'netcdf4',
         'python-dateutil',
         'GDAL',
-        'rasterio==1.0a12',
+        'rasterio==1.0b2',
         'pytest',
     ],
     package_dir={

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'netcdf4',
         'python-dateutil',
         'GDAL',
-        'rasterio==1.0b2',
+        'rasterio',
         'pytest',
     ],
     package_dir={


### PR DESCRIPTION
All of the tests pass (*really* quickly) on my desktop. Is there any reason *not* to do this? I don't seem much in [CHANGES.txt](https://github.com/mapbox/rasterio/blob/master/CHANGES.txt) that should affect us, but there are a few mentions of `rasterize()`, so maybe it has seen some underlying work.