### PR TITLE
Use only multi year means for /data query

### DIFF
--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -130,6 +130,7 @@ def data(sesh, model, emission, time, area, variable, timescale='other',
 
         .join(DataFile.timeset)
         .filter(TimeSet.time_resolution == timescale)
+        .filter(TimeSet.multi_year_mean == True)
 
         .filter(DataFileVariable.ensembles.any(Ensemble.name == ensemble_name))
     )


### PR DESCRIPTION
The` /data` API endpoint is called by the code that generates the Long Term Average graph if the user has selected a multi year mean dataset; it yields a series of values, one for each available period, illustrating change over time. 

This query also adds non-mym datasets to the series, which is not correct, but wasn't an issue and didn't come up until we started using an ensemble with both nominal-time and MYM data.