### PR TITLE
Add streamflow API spec

### DIFF
--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -78,6 +78,23 @@ paths:
         404:
           $ref: '#/components/responses/404NotFound'
 
+  /hydromodel_outputs/{id}/bounds:
+    get:
+      summary: Get bounds of a specific VIC hydrological model output.
+      tags:
+        - Hydromodel outputs
+      parameters:
+        - $ref: '#/components/parameters/hydromodelOutputId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HydromodelOutputBounds'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
   ### Orders
 
   /streamflow/orders:
@@ -451,12 +468,20 @@ components:
             experiment:
               type: string
               example: rcp85
+            cell_x_size:
+              type: number
+              example: 3.75
+              description: Size of grid cells in X (longitude) direction.
+            cell_y_size:
+              type: number
+              example: 2.5
+              description: Size of grid cells in Y (latitude) direction.
             etc:
               type: string
               example: ... more tbd ...
 
     HydromodelOutputHypermedia:
-      description: Hypermedia for a thing
+      description: Hypermedia for a hydromodel output.
       type: object
       properties:
         links:
@@ -465,12 +490,43 @@ components:
             - example:
                 - rel: 'self'
                   uri: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+                - rel: 'bounds'
+                  uri: 'http://apis.paccifcclimate.org/hydromodel_output/4/bounds'
 
     HydromodelOutput:
       description: Full representation of a hydromodel output - state + hypermedia.
       allOf:
         - $ref: '#/components/schemas/HydromodelOutputState'
         - $ref: '#/components/schemas/HydromodelOutputHypermedia'
+
+    HydromodelOutputBounds:
+      description: Geographic bounds of hydromodel data set.
+      type: object
+      properties:
+        bounds:
+          type: object
+          description: GeoJSON defining the bounds
+        links:
+          - $ref: '#/components/schemas/HypermediaLinkList'
+      example:
+        bounds:
+          type: Feature
+          properties:
+            name: Columbia Basin
+            area: 1000000
+          geometry:
+            type: Polygon
+            coordinates:
+              -
+                - [-64.73, 32.31]
+                - [-80.19, 25.76]
+                - [-66.09, 18.43]
+                - [-64.73, 32.31]
+        links:
+          - rel: 'self'
+            uri: 'http://apis.paccifcclimate.org/hydromodel_output/4/bounds'
+          - rel: 'hydromodel_output'
+            uri: 'http://apis.paccifcclimate.org/hydromodel_output/4'
 
     # Lists (collections) of hydromodel outputs
 

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -252,6 +252,36 @@ paths:
         404:
           $ref: '#/components/responses/404NotFound'
 
+  /streamflow/results/{id}/annual-cycle/standard-periods:
+    get:
+      summary: |
+        Get list of links to annual cycle timeseries for standard climatology
+        time periods.
+      description: |
+        Get list of links to annual cycle timeseries for standard climatology periods for specified streamflow. Standard climatology periods are:
+
+        - 1961-1999
+        - 1971-2000
+        - 1981-2010
+        - 2010-2039
+        - 2040-2069
+        - 2070-2099
+
+        The list of links returned are for those periods, limited by the time period spanned by the streamflow result set.
+      tags:
+        - Results
+      parameters:
+        - $ref: '#/components/parameters/resultId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowResultAnnualCycleStandardPeriodList'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
   /streamflow/results/{id}/annual-max:
     get:
       summary: Get annual maximum timeseries for specified streamflow
@@ -805,8 +835,10 @@ components:
             uri: 'https://services.pacificclimate.org/streamflow/results/6'
           - rel: 'deprecate'
             uri: 'https://services.pacificclimate.org/streamflow/results/6'
-          - rel: 'annual-cycle'
+          - rel: 'annual-cycle-template'
             uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/{startYear}-{endYear}'
+          - rel: 'annual-cycle-standard-periods'
+            uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/standard-periods'
           - rel: 'annual-max'
             uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-max'
           - rel: 'annual-mean'
@@ -850,6 +882,52 @@ components:
           start_date: '2000-01-01'
           end_date: '2100-12-31'
 
+    # List of streamflow result annual cycles for standard climatology periods
+
+    StreamflowResultAnnualCycleStandardPeriodsListLitem:
+      description: Hyperlink to annual cycle data for specified period.
+      type: object
+      allOf:
+        - type: object
+          properties:
+            startYear:
+              type: integer
+            endYear:
+              type: integer
+          required:
+            - startYear
+            - endYear
+        - $ref: '#/components/schemas/ListItemUri'
+      example:
+        startYear: 1971
+        endYear: 2000
+        uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/1971-2000'
+
+    StreamflowResultAnnualCycleStandardPeriodList:
+      description: |
+        List of hyperlinks to annual cycle data for standard climatology periods.
+      type: array
+      items:
+        $ref: '#/components/schemas/StreamflowResultAnnualCycleStandardPeriodsListLitem'
+      example:
+        - startYear: 1961
+          endYear: 1999
+          uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/1961-1999'
+        - startYear: 1971
+          endYear: 2000
+          uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/1971-2000'
+        - startYear: 1981
+          endYear: 2010
+          uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/1981-2010'
+        - startYear: 2010
+          endYear: 2039
+          uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/2010-2039'
+        - startYear: 2040
+          endYear: 2069
+          uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/2040-2069'
+        - startYear: 2070
+          endYear: 2099
+          uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/2070-2099'
 
     # Streamflow result data
 

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -166,7 +166,7 @@ paths:
     delete:
       summary: Cancel a streamflow order
       description: |
-        If the streamflow order is not cancellable (not in 'processing' status), response status is 409 Conflict.
+        If the streamflow order is not cancellable (not in 'accepted' status), response status is 409 Conflict.
       tags:
         - Orders
       parameters:
@@ -692,7 +692,7 @@ components:
             status:
               description: See [order lifecycle](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-OrderLifecycle).
               type: string
-              enum: [processing, fulfilled, cancelled, error]
+              enum: [accepted, fulfilled, cancelled, error]
           required:
             - id
             - status

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -32,10 +32,11 @@ tags:
 
         However, because of of asynchrony and caching, matching orders (containing the same parameters) may be fulfilled by different result resources (represented by the /streamflowss resource collection) as result resources become invalidated in the cache. In other words, if a result has to be regenerated, it is a different resource that contains identical data computed at a different time.
 
+        For detailed information, see the [order lifecycle]https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-OrderLifecycle).
 
   - name: Results
     description: |
-      A result resource represents result of a streamflow computation.
+      A result resource represents the result of a streamflow computation.
 
       Computing a result is time consuming. Therefore a result may be in a pending status (computation not complete) state.
 
@@ -43,6 +44,7 @@ tags:
 
       Over time, result data for a single set of streamflow computation parameters may be computed and cached, then invalidated (removed from cache), then recomputed and cached again, etc. The actual data computed is identical for matching sets of streamflow computation parameters, but they are actually distinct objects. Therefore result resources that represent different (re)computations of the same data are distinct, i.e, have different URIs.
 
+      For detailed information, see [result lifecycle](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-ResultLifecycle).
 
 paths:
 
@@ -143,8 +145,9 @@ paths:
     get:
       summary: Get existing streamflow order
       description: |
-        Content of the `links` property depends on the value of the `status` property.
-        If `status /= 'fulfilled'`, the data links are absent.
+        Content of the `links` property depends on the value of the `status` property. If `status /= 'fulfilled'`, the data links are absent.
+
+        For status values and meanings, see the [order lifecycle]https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-OrderLifecycle).
       tags:
         - Orders
       parameters:
@@ -163,7 +166,7 @@ paths:
     delete:
       summary: Cancel a streamflow order
       description: |
-        If the streamflow order is not cancellable (not in pending status), response status is 409 Conflict.
+        If the streamflow order is not cancellable (not in 'processing' status), response status is 409 Conflict.
       tags:
         - Orders
       parameters:
@@ -196,6 +199,8 @@ paths:
   /streamflow/results/{id}:
     get:
       summary: Get metadata of a streamflow result
+      description: |
+        For status values and meanings, see [result lifecycle](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-ResultLifecycle).
       tags:
         - Results
       parameters:
@@ -211,7 +216,13 @@ paths:
           $ref: '#/components/responses/404NotFound'
 
     delete:
-      summary: Deprecate a streamflow result (mark as no longer needed)
+      summary: Cancel or deprecate (mark as no longer needed) a streamflow result.
+      description: |
+        A result can be cancelled if its status is `queued` or `processing`.
+
+        A result can be deprecated if its status is `ready`.
+
+        For status values and meanings, see [result lifecycle](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-ResultLifecycle).
       tags:
         - Results
       parameters:
@@ -679,9 +690,9 @@ components:
               description: Unique id of streamflow order
               type: integer
             status:
-              description: See streamflow order state diagram.
+              description: See [order lifecycle](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-OrderLifecycle).
               type: string
-              enum: [pending, cancelled, fulfilled, deprecated]
+              enum: [processing, fulfilled, cancelled, error]
           required:
             - id
             - status
@@ -790,8 +801,9 @@ components:
         - type: object
           properties:
             status:
+              description: See [result lifecycle](https://pcic.uvic.ca/confluence/pages/viewpage.action?pageId=24117297#StreamflowArchitectureII-ResultLifecycle).
               type: string
-              enum: [processing, ready, removed]
+              enum: [queued, processing, ready, removed, cancelled, errored]
             hydromodel_output_id:
               $ref: '#/components/schemas/HydromodelOutputId'
             cell_x:

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -120,7 +120,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StreamflowOrder'
+                $ref: '#/components/schemas/StreamflowOrderNew'
         401:
           $ref: '#/components/responses/401Unauthorized'
 
@@ -142,6 +142,9 @@ paths:
   /streamflow/orders/{id}:
     get:
       summary: Get existing streamflow order
+      description: |
+        Content of the `links` property depends on the value of the `status` property.
+        If `status /= 'fulfilled'`, the data links are absent.
       tags:
         - Orders
       parameters:
@@ -152,7 +155,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StreamflowOrder'
+                $ref: '#/components/schemas/StreamflowOrderGeneric'
         404:
           $ref: '#/components/responses/404NotFound'
 
@@ -589,7 +592,6 @@ components:
           properties:
             id:
               type: integer
-              example: 5
             status:
               type: string
               enum: [pending, cancelled, fulfilled, deprecated]
@@ -601,29 +603,67 @@ components:
       type: object
       properties:
         links:
-          allOf:
-            - $ref: '#/components/schemas/HypermediaLinkList'
-            - example:
-                - rel: 'self'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
-                - rel: 'cancel'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
-                - rel: 'hydromodel_output'
-                  uri: 'http://apis.paccifcclimate.org/hydromodel_outputs/4'
-                - rel: 'results/metadata'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
-                - rel: 'results/annual-max'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-max'
-                - rel: 'results/annual-mean'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-mean'
-                - rel: 'results/annual-cycle'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-cycle'
+          $ref: '#/components/schemas/HypermediaLinkList'
 
     StreamflowOrder:
-      description: Representation of a streamflow order - state + hypermedia.
+      description: Representation of a streamflow order = state + hypermedia.
       allOf:
         - $ref: '#/components/schemas/StreamflowOrderState'
         - $ref: '#/components/schemas/StreamflowOrderHypermedia'
+
+    StreamflowOrderNew:
+      description: Representation of a new streamflow order.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/StreamflowOrder'
+        - example:
+            id: 5
+            status: pending
+            longitude: -123.5
+            latitude: 48.5
+            notification:
+              method: email
+              address: example@uvic.ca
+            links:
+              - rel: 'self'
+                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+              - rel: 'cancel'
+                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+              - rel: 'hydromodel_output'
+                uri: 'http://apis.paccifcclimate.org/hydromodel_outputs/4'
+
+    StreamflowOrderGeneric:
+      description: Representation of a generic streamflow order.
+      type: object
+      # Using `allOf` here to include both schema and example should not be
+      # necessary. The `$ref` and `example` properties should be at the same
+      # level as `description`, `type`; but for some reason this fails in
+      # the Swagger editor.
+      allOf:
+        - $ref: '#/components/schemas/StreamflowOrder'
+        - example:
+            id: 5
+            status: fulfilled
+            longitude: -123.5
+            latitude: 48.5
+            notification:
+              method: email
+              address: example@uvic.ca
+            links:
+              - rel: 'self'
+                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+              - rel: 'cancel'
+                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+              - rel: 'hydromodel_output'
+                uri: 'http://apis.paccifcclimate.org/hydromodel_outputs/4'
+              - rel: 'results/metadata'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+              - rel: 'results/annual-max'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-max'
+              - rel: 'results/annual-mean'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-mean'
+              - rel: 'results/annual-cycle'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-cycle'
 
     # List of streamflow orders
 

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -507,7 +507,7 @@ components:
           type: object
           description: GeoJSON defining the bounds
         links:
-          - $ref: '#/components/schemas/HypermediaLinkList'
+          $ref: '#/components/schemas/HypermediaLinkList'
       example:
         bounds:
           type: Feature

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -143,7 +143,7 @@ paths:
     delete:
       summary: Cancel a streamflow order
       description: |
-        If the streamflow order is not cancellable (not in pending status), response status is 409 409Conflict.
+        If the streamflow order is not cancellable (not in pending status), response status is 409 Conflict.
       tags:
         - Orders
       parameters:
@@ -362,7 +362,7 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
           example:
-            code: '401'
+            code: '409'
             message: Message giving details of conflict
 
   schemas:

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -773,7 +773,7 @@ components:
               - rel: 'deprecate'
                 uri: 'https://services.pacificclimate.org/streamflow/results/6'
               - rel: 'annual-cycle'
-                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/{startYear}-{endYear}'
               - rel: 'annual-max'
                 uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-max'
               - rel: 'annual-mean'

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -682,6 +682,18 @@ components:
           description: y-index of streamflow cell
           type: integer
           example: 33
+        start_date:
+          description: Date-time of first timestep in streamflow results (ISO 8601)
+          type: string
+          example: '2000-01-01'
+        end_date:
+          description: Date-time of last timestep in streamflow results (ISO 8601)
+          type: string
+          example: '2100-12-31'
+        time_resolution:
+          description: Interval between timesteps in streamflow results (ISO 8601 duration)
+          type: string
+          example: 'PD1'
 
     StreamflowResultHypermedia:
       type: object

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -404,25 +404,31 @@ components:
         code: '404'
         message: Message giving details of problem
 
-    URI:
-      description: URI property
-      type: object
-      properties:
-        uri:
-          type: string
-
     GridCellSize:
       description: Size of a model grid cell
       type: object
       properties:
         cell_x_size:
-          type: float
-          example: 3.75
           description: Size of grid cell in X (longitude) direction.
+          type: number
         cell_y_size:
-          type: float
-          example: 2.5
           description: Size of grid cell in Y (latitude) direction.
+          type: number
+      required:
+        - cell_x_size
+        - cell_y_size
+      example:
+        cell_x_size: 3.75
+        cell_y_size: 2.5
+
+    ListItemUri:
+      type: object
+      properties:
+        uri:
+          description: URI of individual item listed
+          type: string
+      required:
+        - uri
 
     HypermediaLink:
       description: Annotated hypermedia link to a related resource
@@ -442,6 +448,15 @@ components:
       items:
         $ref: '#/components/schemas/HypermediaLink'
 
+    HypermediaLinks:
+      description: Standard property in representations that holds hypermedia links
+      type: object
+      properties:
+        links:
+          $ref: '#/components/schemas/HypermediaLinkList'
+      required:
+        - links
+
     TemporalBounds:
       description: Metadata describing temporal bounds of a dataset.
       type: object
@@ -449,11 +464,15 @@ components:
         start_date:
           description: Date-time of first timestep in dataset (ISO 8601)
           type: string
-          example: '2000-01-01'
         end_date:
           description: Date-time of last timestep in dataset (ISO 8601)
           type: string
-          example: '2100-12-31'
+      required:
+        - start_date
+        - end_date
+      example:
+        start_date: '2000-01-01'
+        end_date: '2100-12-31'
 
     Timeseries:
       description: A time series, which is to say a set of values at specified times.
@@ -493,32 +512,33 @@ components:
             hydromodel_output_id:
               $ref: '#/components/schemas/HydromodelOutputId'
             model:
+              description: Short identifier of model providing climate input to hydromodel
               type: string
-              example: CanESM2
             experiment:
+              description: Short identifier of experiment (emissions scenario) providing climate input to hydromodel
               type: string
-              example: rcp85
+          required:
+            - hydromodel_output_id
+            - model
+            - experiment
+          example:
+            hydromodel_output_id: 4
+            model: CanESM2
+            experiment: rcp85
         - $ref: '#/components/schemas/GridCellSize'
         - $ref: '#/components/schemas/TemporalBounds'
-
-    HydromodelOutputHypermedia:
-      description: Hypermedia for a hydromodel output.
-      type: object
-      properties:
-        links:
-          allOf:
-            - $ref: '#/components/schemas/HypermediaLinkList'
-            - example:
-                - rel: 'self'
-                  uri: 'https://services.pacificclimate.org/hydromodel_output/4'
-                - rel: 'bounds'
-                  uri: 'https://services.pacificclimate.org/hydromodel_output/4/bounds'
 
     HydromodelOutput:
       description: Full representation of a hydromodel output - state + hypermedia.
       allOf:
         - $ref: '#/components/schemas/HydromodelOutputState'
-        - $ref: '#/components/schemas/HydromodelOutputHypermedia'
+        - $ref: '#/components/schemas/HypermediaLinks'
+      example:
+        links:
+          - rel: 'self'
+            uri: 'https://services.pacificclimate.org/hydromodel_output/4'
+          - rel: 'bounds'
+            uri: 'https://services.pacificclimate.org/hydromodel_output/4/bounds'
 
     HydromodelOutputBounds:
       description: Geographic bounds of hydromodel data set.
@@ -529,6 +549,9 @@ components:
           description: GeoJSON defining the bounds
         links:
           $ref: '#/components/schemas/HypermediaLinkList'
+      required:
+        - bounds
+        - links
       example:
         bounds:
           type: Feature
@@ -555,13 +578,7 @@ components:
       description: Representation of a single item in a list of hydromodel outputs.
       type: object
       allOf:
-        - type: object
-          properties:
-            uri:
-              type: string
-              description: URI of hydromodel output
-              example: 'https://services.pacificclimate.org/hydromodel_output/4'
-        - $ref: '#/components/schemas/HypermediaLinkList'
+        - $ref: '#/components/schemas/ListItemUri'
         - $ref: '#/components/schemas/HydromodelOutputState'
 
     HydromodelOutputList:
@@ -590,17 +607,15 @@ components:
     # Individual streamflow orders
 
     StreamflowOrderStateNew:
-      description: Defines a new order for a streamflow result set.
+      description: Data required to define a new order for a streamflow result set.
       type: object
       properties:
         hydromodel_output_id:
           $ref: '#/components/schemas/HydromodelOutputId'
         longitude:
           type: number
-          example: -123.5
         latitude:
           type: number
-          example: 48.5
         notification:
           type: object
           properties:
@@ -609,7 +624,21 @@ components:
               enum: [email]
             address:
               type: string
-              example: example@uvic.ca
+          required:
+            - method
+            - address
+      required:
+        - hydromodel_output_id
+        - latitude
+        - longitude
+        - notification
+      example:
+        hydromodel_output_id: 4
+        longitude: -123.5
+        latitude: 48.5
+        notification:
+          method: email
+          address: example@uvic.ca
 
     StreamflowOrderState:
       description: State for a streamflow order
@@ -617,28 +646,25 @@ components:
         - type: object
           properties:
             id:
+              description: Unique id of streamflow order
               type: integer
             status:
+              description: See streamflow order state diagram.
               type: string
               enum: [pending, cancelled, fulfilled, deprecated]
-              example: fulfilled
+          required:
+            - id
+            - status
         - $ref: '#/components/schemas/StreamflowOrderStateNew'
-
-    StreamflowOrderHypermedia:
-      description: Hypermedia for a streamflow order
-      type: object
-      properties:
-        links:
-          $ref: '#/components/schemas/HypermediaLinkList'
 
     StreamflowOrder:
       description: Representation of a streamflow order = state + hypermedia.
       allOf:
         - $ref: '#/components/schemas/StreamflowOrderState'
-        - $ref: '#/components/schemas/StreamflowOrderHypermedia'
+        - $ref: '#/components/schemas/HypermediaLinks'
 
     StreamflowOrderNew:
-      description: Representation of a new streamflow order.
+      description: Representation of a newly created streamflow order.
       type: object
       allOf:
         - $ref: '#/components/schemas/StreamflowOrder'
@@ -697,12 +723,7 @@ components:
       description: List of streamflow results
       type: object
       allOf:
-        - type: object
-          properties:
-            uri:
-              type: string
-              description: URI of streamflow order
-              example: 'https://services.pacificclimate.org/streamflow/orders/5'
+        - $ref: '#/components/schemas/ListItemUri'
         - $ref: '#/components/schemas/StreamflowOrderState'
 
     StreamflowOrderList:
@@ -712,6 +733,7 @@ components:
         $ref: '#/components/schemas/StreamflowOrderListItem'
       example:
         - uri: 'https://services.pacificclimate.org/streamflow/orders/5'
+          id: 5
           hydromodel_output_id: 4
           longitude: -123.5
           latitude: 48.5
@@ -719,6 +741,7 @@ components:
             method: email
             address: abc@example.ca
         - uri: 'https://services.pacificclimate.org/streamflow/orders/6'
+          id: 6
           hydromodel_output_id: 5
           longitude: -120.0
           latitude: 50.2
@@ -739,52 +762,55 @@ components:
             status:
               type: string
               enum: [processing, ready, removed]
-              example: ready
             hydromodel_output_id:
               $ref: '#/components/schemas/HydromodelOutputId'
             cell_x:
               description: x coordinate (longitude) of cell centre
-              type: float
-              example: -118.7
+              type: number
             cell_y:
               description: y coordinate (longitude) of cell centre
-              type: float
-              example: 54.25
+              type: number
             cell_x_index:
               description: x-index of streamflow cell
               type: integer
-              example: 27
             cell_y_index:
               description: y-index of streamflow cell
               type: integer
-              example: 33
+          required:
+            - status
+            - hydromodel_output_id
+            - cell_x
+            - cell_y
+            - cell_x_index
+            - cell_y_index
+          example:
+            status: ready
+            hydromodel_output_id: 4
+            cell_x: -118.7
+            cell_y: 54.25
+            cell_x_index: 27
+            cell_y_index: 33
         - $ref: '#/components/schemas/GridCellSize'
         - $ref: '#/components/schemas/TemporalBounds'
-
-    StreamflowResultHypermedia:
-      type: object
-      properties:
-        links:
-          allOf:
-            - $ref: '#/components/schemas/HypermediaLinkList'
-            - example:
-              - rel: 'self'
-                uri: 'https://services.pacificclimate.org/streamflow/results/6'
-              - rel: 'deprecate'
-                uri: 'https://services.pacificclimate.org/streamflow/results/6'
-              - rel: 'annual-cycle'
-                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/{startYear}-{endYear}'
-              - rel: 'annual-max'
-                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-max'
-              - rel: 'annual-mean'
-                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-mean'
 
     StreamflowResult:
       description: Metadata and hyperlinks for a single streamflow result
       type: object
       allOf:
         - $ref: '#/components/schemas/StreamflowResultState'
-        - $ref: '#/components/schemas/StreamflowResultHypermedia'
+        - $ref: '#/components/schemas/HypermediaLinks'
+      example:
+        links:
+          - rel: 'self'
+            uri: 'https://services.pacificclimate.org/streamflow/results/6'
+          - rel: 'deprecate'
+            uri: 'https://services.pacificclimate.org/streamflow/results/6'
+          - rel: 'annual-cycle'
+            uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle/{startYear}-{endYear}'
+          - rel: 'annual-max'
+            uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-max'
+          - rel: 'annual-mean'
+            uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-mean'
 
     # List of streamflow results
 
@@ -792,12 +818,7 @@ components:
       description: Item in list of streamflow results
       type: object
       allOf:
-        - type: object
-          properties:
-            uri:
-              type: string
-              description: URI of streamflow result
-              example: 'https://services.pacificclimate.org/streamflow/results/6'
+        - $ref: '#/components/schemas/ListItemUri'
         - $ref: '#/components/schemas/StreamflowResultState'
 
     StreamflowResultList:
@@ -856,7 +877,8 @@ components:
       properties:
         prop:
           type: number
-          example: -123.5
+      example:
+        prop: -123.5
 
     ThingState:
       description: State for a thing. Contains complete state.
@@ -865,33 +887,28 @@ components:
           properties:
             id:
               type: integer
-              example: 5
             etc:
               type: string
         - $ref: '#/components/schemas/ThingStateNew'
+      example:
+        id: 5
+        etc: exciting
 
-    ThingHypermedia:
-      description: Hypermedia for a thing
-      type: object
-      properties:
-        links:
-          allOf:
-            - $ref: '#/components/schemas/HypermediaLinkList'
-            - example:
-                - rel: 'self'
-                  uri: 'https://services.pacificclimate.org/streamflow/orders/5'
-                - rel: 'https://services.pacificclimate.org/relations/streamflow/orders/cancel'
-                  uri: 'https://services.pacificclimate.org/streamflow/orders/5'
-                - rel: 'https://services.pacificclimate.org/relations/streamflow/results/metadata'
-                  uri: 'https://services.pacificclimate.org/streamflow/results/6'
-                - rel: 'https://services.pacificclimate.org/relations/streamflow/results/timeseries'
-                  uri: 'https://services.pacificclimate.org/streamflow/results/6/timeseries'
 
     Thing:
       description: Representation of a thing - state + hypermedia.
       allOf:
         - $ref: '#/components/schemas/ThingState'
-        - $ref: '#/components/schemas/ThingHypermedia'
+        - $ref: '#/components/schemas/HypermediaLinks'
+      example:
+        - rel: 'self'
+          uri: 'https://services.pacificclimate.org/streamflow/orders/5'
+        - rel: 'https://services.pacificclimate.org/relations/streamflow/orders/cancel'
+          uri: 'https://services.pacificclimate.org/streamflow/orders/5'
+        - rel: 'https://services.pacificclimate.org/relations/streamflow/results/metadata'
+          uri: 'https://services.pacificclimate.org/streamflow/results/6'
+        - rel: 'https://services.pacificclimate.org/relations/streamflow/results/timeseries'
+          uri: 'https://services.pacificclimate.org/streamflow/results/6/timeseries'
 
     # Lists (collections) of things
 
@@ -899,12 +916,7 @@ components:
       description: Representation of a single item in a list of things.
       type: object
       allOf:
-        - type: object
-          properties:
-            uri:
-              type: string
-              description: URI of thing
-        - $ref: '#/components/schemas/HypermediaLinkList'
+        - $ref: '#/components/schemas/ListItemUri'
         - $ref: '#/components/schemas/ThingState'
 
     ThingList:

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -411,6 +411,19 @@ components:
         uri:
           type: string
 
+    GridCellSize:
+      description: Size of a model grid cell
+      type: object
+      properties:
+        cell_x_size:
+          type: float
+          example: 3.75
+          description: Size of grid cell in X (longitude) direction.
+        cell_y_size:
+          type: float
+          example: 2.5
+          description: Size of grid cell in Y (latitude) direction.
+
     HypermediaLink:
       description: Annotated hypermedia link to a related resource
       type: object
@@ -485,14 +498,7 @@ components:
             experiment:
               type: string
               example: rcp85
-            cell_x_size:
-              type: number
-              example: 3.75
-              description: Size of grid cells in X (longitude) direction.
-            cell_y_size:
-              type: number
-              example: 2.5
-              description: Size of grid cells in Y (latitude) direction.
+        - $ref: '#/components/schemas/GridCellSize'
         - $ref: '#/components/schemas/TemporalBounds'
 
     HydromodelOutputHypermedia:
@@ -737,13 +743,22 @@ components:
             hydromodel_output_id:
               $ref: '#/components/schemas/HydromodelOutputId'
             cell_x:
+              description: x coordinate (longitude) of cell centre
+              type: float
+              example: -118.7
+            cell_y:
+              description: y coordinate (longitude) of cell centre
+              type: float
+              example: 54.25
+            cell_x_index:
               description: x-index of streamflow cell
               type: integer
               example: 27
-            cell_y:
+            cell_y_index:
               description: y-index of streamflow cell
               type: integer
               example: 33
+        - $ref: '#/components/schemas/GridCellSize'
         - $ref: '#/components/schemas/TemporalBounds'
 
     StreamflowResultHypermedia:
@@ -794,15 +809,23 @@ components:
         - uri: 'https://services.pacificclimate.org/streamflow/results/6'
           status: ready
           hydromodel_output_id: 4
-          cell_x: 27
-          cell_y: 33
+          cell_x_size: 3.75
+          cell_y_size: 2.5
+          cell_x: -118.7
+          cell_y: 54.2
+          cell_x_index: 27
+          cell_y_index: 33
           start_date: '2000-01-01'
           end_date: '2100-12-31'
         - uri: 'https://services.pacificclimate.org/streamflow/results/7'
           status: ready
           hydromodel_output_id: 5
-          cell_x: 18
-          cell_y: 99
+          cell_x_size: 3.75
+          cell_y_size: 2.5
+          cell_x: -123.7
+          cell_y: 60.8
+          cell_x_index: 18
+          cell_y_index: 99
           start_date: '2000-01-01'
           end_date: '2100-12-31'
 

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -1,0 +1,768 @@
+openapi: 3.0.0
+info:
+  version: "1.1.0"
+  title: Routed streamflow backend API
+  description: Web service providing resources necessary to support streamflow web app
+
+servers:
+  - url: http://services.pacificclimate.org
+
+tags:
+  - name: Hydromodel outputs
+    description: |
+      Hydrological model outputs are used as inputs by the streamflow computation.
+
+      Hydrological model outputs are gridded fields of baseflow and runoff. A set of hydrological model outputs (baseflow and runoff fields) is the result of a hydrological model run, which is a run of the hydrological model with particular input files and parameters.
+
+      A hydrological model run and its outputs are characterized (for our purposes) by the following inputs to the hydrological model.
+
+      - a specific hydrographic model - soil types, etc. defined over a gridded spatial field
+
+      - a specific climate - a time series of gridded spatial fields of observed or simulated climate variables relevant to hydrology (e.g., temperature, precipitation)
+
+      These characterizing inputs, and therefore the hydrological model run and its outputs, are uniquely identified by a set of metadata. For example, the hydrographic model has a name; the climate model has model and scenario identifiers.
+
+      Note This is a static resource collection in the sense that its content is determined by activities that are not controlled by the backend (specifically, running the VIC model, and indexing the results of those runs in the database).
+
+  - name: Orders
+    description: |
+        Since the streamflow computation is time consuming, its results are in general not available immediately. (Results may be available immediately if it has been requested recently and is still in the results cache.) Therefore we introduce the order system as an intermediary between the request and the result proper.
+
+        In terms of the actual streamflow data that is computed and delivered, matching orders (containing the same parameters) will be fulfilled by identical streamflow data.
+
+        However, because of of asynchrony and caching, matching orders (containing the same parameters) may be fulfilled by different result resources (represented by the /streamflowss resource collection) as result resources become invalidated in the cache. In other words, if a result has to be regenerated, it is a different resource that contains identical data computed at a different time.
+
+
+  - name: Results
+    description: |
+      A result resource represents result of a streamflow computation.
+
+      Computing a result is time consuming. Therefore a result may be in a pending status (computation not complete) state.
+
+      Result data is bulky. Therefore result data is maintained in a cache, and a completed result may be in-cache (status ready) or invalidated (out of cache; status invalidated).
+
+      Over time, result data for a single set of streamflow computation parameters may be computed and cached, then invalidated (removed from cache), then recomputed and cached again, etc. The actual data computed is identical for matching sets of streamflow computation parameters, but they are actually distinct objects. Therefore result resources that represent different (re)computations of the same data are distinct, i.e, have different URIs.
+
+
+paths:
+
+  ### Hydromodel outputs
+
+  /hydromodel_outputs:
+    get:
+      summary: Get descriptions of all VIC hydrological model outputs available for driving streamflow modelling.
+      tags:
+        - Hydromodel outputs
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HydromodelOutputList'
+
+  /hydromodel_outputs/{id}:
+    get:
+      summary: Get description of a specific VIC hydrological model output.
+      tags:
+        - Hydromodel outputs
+      parameters:
+        - $ref: '#/components/parameters/hydromodelOutputId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HydromodelOutput'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
+  ### Orders
+
+  /streamflow/orders:
+    post:
+      summary: Create a new order for the result of a streamflow computation
+      tags:
+        - Orders
+      requestBody:
+        description: Parameters defining a streamflow order.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StreamflowOrderStateNew'
+      responses:
+        201:
+          description: Success. A new order has been created.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: URI of newly created order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowOrder'
+        401:
+          $ref: '#/components/responses/401Unauthorized'
+
+    get:
+      summary: Get a list of all currently pending orders for streamflow computations, filtered by user
+      tags:
+        - Orders
+      parameters:
+        - $ref: '#/components/parameters/userId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowOrderList'
+
+
+  /streamflow/orders/{id}:
+    get:
+      summary: Get existing streamflow order
+      tags:
+        - Orders
+      parameters:
+        - $ref: '#/components/parameters/orderId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowOrder'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
+
+    delete:
+      summary: Cancel a streamflow order
+      description: |
+        If the streamflow order is not cancellable (not in pending status), response status is 409 409Conflict.
+      tags:
+        - Orders
+      parameters:
+        - $ref: '#/components/parameters/orderId'
+      responses:
+        204:
+          $ref: '#/components/responses/204NoContent'
+        401:
+          $ref: '#/components/responses/401Unauthorized'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        409:
+          $ref: '#/components/responses/409Conflict'
+
+  ### Results
+
+  /streamflow/results:
+    get:
+      summary: List currently ready streamflow results
+      tags:
+        - Results
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowResultList'
+
+  /streamflow/results/{id}:
+    get:
+      summary: Get metadata of a streamflow result
+      tags:
+        - Results
+      parameters:
+        - $ref: '#/components/parameters/resultId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowResult'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
+    delete:
+      summary: Deprecate a streamflow result (mark as no longer needed)
+      tags:
+        - Results
+      parameters:
+        - $ref: '#/components/parameters/resultId'
+      responses:
+        204:
+          $ref: '#/components/responses/204NoContent'
+        401:
+          $ref: '#/components/responses/401Unauthorized'
+        404:
+          $ref: '#/components/responses/404NotFound'
+        409:
+          $ref: '#/components/responses/409Conflict'
+
+
+  /streamflow/results/{id}/annual-cycle/{startYear}-{endYear}:
+    get:
+      summary: Get annual cycle timeseries for specified streamflow
+      description: |
+        If the streamflow result is not in ready status, response status is 404 Not Found.
+        If start date >= end date, response status is 400 Bad Request
+      tags:
+        - Results
+      parameters:
+        - $ref: '#/components/parameters/resultId'
+        - $ref: '#/components/parameters/startYear'
+        - $ref: '#/components/parameters/endYear'
+
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowResultAnnualCycle'
+        400:
+          $ref: '#/components/responses/400BadRequest'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
+  /streamflow/results/{id}/annual-max:
+    get:
+      summary: Get annual maximum timeseries for specified streamflow
+      description: |
+        If the streamflow result is not in ready status, response status is 404 Not Found.
+      tags:
+        - Results
+      parameters:
+        - $ref: '#/components/parameters/resultId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowResultAnnualMax'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
+  /streamflow/results/{id}/annual-mean:
+    get:
+      summary: Get annual mean timeseries for specified streamflow
+      description: |
+        If the streamflow result is not in ready status, response status is 404 Not Found.
+      tags:
+        - Results
+      parameters:
+        - $ref: '#/components/parameters/resultId'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreamflowResultAnnualMean'
+        404:
+          $ref: '#/components/responses/404NotFound'
+
+
+components:
+  parameters:
+    hydromodelOutputId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Unique id of a hydromodel output resource.
+
+    orderId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Unique id of an order resource.
+
+    resultId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Unique id of result resource.
+
+    startYear:
+      name: startYear
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: First year of a multi-year period
+
+    endYear:
+      name: endYear
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Last year of a multi-year period
+
+    userId:
+      name: userid
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Id of user.
+
+  responses:
+    204NoContent:
+      description: Success. No content.
+
+    400BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: '400'
+            message: Message giving details of problem with request
+
+    401Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: '401'
+            message: Message giving details of authorization problem
+
+    404NotFound:
+      description: The specified resource was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: '404'
+            message: Resource not found
+
+    409Conflict:
+      description: Attempt to put resource into impossible, inconsistent, or unavailable state.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            code: '401'
+            message: Message giving details of conflict
+
+  schemas:
+
+    ### Generic schemas
+
+    Error:
+      description: Generic error response body
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+      example:
+        code: '404'
+        message: Message giving details of problem
+
+    URI:
+      description: URI property
+      type: object
+      properties:
+        uri:
+          type: string
+
+    HypermediaLink:
+      description: Annotated hypermedia link to a related resource
+      type: object
+      properties:
+        rel:
+          type: string
+        uri:
+          type: string
+      required:
+        - rel
+        - uri
+
+    HypermediaLinkList:
+      description: List of annotated hypermedia links to related resources
+      type: array
+      items:
+        $ref: '#/components/schemas/HypermediaLink'
+
+    Timeseries:
+      description: A time series, which is to say a set of values at specified times.
+        Data points are (time[i], value[i]).
+      type: object
+      properties:
+        times:
+          description: Time coordinates, specified as ISO8601 date-time strings.
+          type: array
+          items:
+            type: string
+          example: ["2000-01-15", "2000-02-15"]
+        values:
+          type: array
+          items:
+            type: number
+          example: [5000, 6000]
+      required:
+        - times
+        - values
+
+    ### Hydromodel outputs
+
+    # Individual hydromodel outputs
+
+    HydromodelOutputId:
+      description: Unique id of hydromodel output that drives a streamflow computation
+      type: integer
+      example: 4
+
+    HydromodelOutputState:
+      description: State for a hydromodel output. Contains complete state.
+      allOf:
+        - type: object
+          properties:
+            hydromodel_output_id:
+              $ref: '#/components/schemas/HydromodelOutputId'
+            model:
+              type: string
+              example: CanESM2
+            experiment:
+              type: string
+              example: rcp85
+            etc:
+              type: string
+              example: ... more tbd ...
+
+    HydromodelOutputHypermedia:
+      description: Hypermedia for a thing
+      type: object
+      properties:
+        links:
+          allOf:
+            - $ref: '#/components/schemas/HypermediaLinkList'
+            - example:
+                - rel: 'self'
+                  uri: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+
+    HydromodelOutput:
+      description: Full representation of a hydromodel output - state + hypermedia.
+      allOf:
+        - $ref: '#/components/schemas/HydromodelOutputState'
+        - $ref: '#/components/schemas/HydromodelOutputHypermedia'
+
+    # Lists (collections) of hydromodel outputs
+
+    HydromodelOutputListItem:
+      description: Representation of a single item in a list of hydromodel outputs.
+      type: object
+      allOf:
+        - type: object
+          properties:
+            uri:
+              type: string
+              description: URI of hydromodel output
+              example: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+        - $ref: '#/components/schemas/HypermediaLinkList'
+        - $ref: '#/components/schemas/HydromodelOutputState'
+
+    HydromodelOutputList:
+      description: List of hydromodel outputs in collection.
+      type: array
+      items:
+        $ref: '#/components/schemas/HydromodelOutputListItem'
+      example:
+        - uri: 'http://apis.paccifcclimate.org/hydromodel_output/3'
+          model: "CanESM2"
+          experiment: "rcp45"
+        - uri: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+          model: "CanESM2"
+          experiment: "rcp85"
+
+    ### Streamflow orders
+
+    # Individual streamflow orders
+
+    StreamflowOrderStateNew:
+      description: Defines a new order for a streamflow result set.
+      type: object
+      properties:
+        hydromodel_output_id:
+          $ref: '#/components/schemas/HydromodelOutputId'
+        longitude:
+          type: number
+          example: -123.5
+        latitude:
+          type: number
+          example: 48.5
+        notification:
+          type: object
+          properties:
+            method:
+              type: string
+              enum: [email]
+            address:
+              type: string
+              example: example@uvic.ca
+
+    StreamflowOrderState:
+      description: State for a streamflow order
+      allOf:
+        - type: object
+          properties:
+            id:
+              type: integer
+              example: 5
+            status:
+              type: string
+              enum: [pending, cancelled, fulfilled, deprecated]
+              example: fulfilled
+        - $ref: '#/components/schemas/StreamflowOrderStateNew'
+
+    StreamflowOrderHypermedia:
+      description: Hypermedia for a streamflow order
+      type: object
+      properties:
+        links:
+          allOf:
+            - $ref: '#/components/schemas/HypermediaLinkList'
+            - example:
+                - rel: 'self'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                - rel: 'cancel'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                - rel: 'hydromodel_output'
+                  uri: 'http://apis.paccifcclimate.org/hydromodel_outputs/4'
+                - rel: 'results/metadata'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+                - rel: 'results/annual-max'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-max'
+                - rel: 'results/annual-mean'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-mean'
+                - rel: 'results/annual-cycle'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-cycle'
+
+    StreamflowOrder:
+      description: Representation of a streamflow order - state + hypermedia.
+      allOf:
+        - $ref: '#/components/schemas/StreamflowOrderState'
+        - $ref: '#/components/schemas/StreamflowOrderHypermedia'
+
+    # List of streamflow orders
+
+    StreamflowOrderListItem:
+      description: List of streamflow results
+      type: object
+      allOf:
+        - type: object
+          properties:
+            uri:
+              type: string
+              description: URI of streamflow order
+              example: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+        - $ref: '#/components/schemas/StreamflowOrderState'
+
+    StreamflowOrderList:
+      description: List of streamflow results
+      type: array
+      items:
+        $ref: '#/components/schemas/StreamflowOrderListItem'
+      example:
+        - uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+          hydromodel_output_id: 4
+          longitude: -123.5
+          latitude: 48.5
+          notification:
+            method: email
+            address: abc@example.ca
+        - uri: 'http://apis.paccifcclimate.org/streamflow/orders/6'
+          hydromodel_output_id: 5
+          longitude: -120.0
+          latitude: 50.2
+          notification:
+            method: email
+            address: def@example.ca
+
+    ### Streamflow results
+
+    # Individual streamflow results
+
+    StreamflowResultState:
+      description: State describing a streamflow result
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [processing, ready, removed]
+          example: ready
+        hydromodel_output_id:
+          $ref: '#/components/schemas/HydromodelOutputId'
+        cell_x:
+          description: x-index of streamflow cell
+          type: integer
+          example: 27
+        cell_y:
+          description: y-index of streamflow cell
+          type: integer
+          example: 33
+
+    StreamflowResultHypermedia:
+      type: object
+      properties:
+        links:
+          allOf:
+            - $ref: '#/components/schemas/HypermediaLinkList'
+            - example:
+              - rel: 'self'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+              - rel: 'deprecate'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+              - rel: 'annual-cycle'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-cycle'
+              - rel: 'annual-max'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-max'
+              - rel: 'annual-mean'
+                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-mean'
+
+    StreamflowResult:
+      description: Metadata and hyperlinks for a single streamflow result
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/StreamflowResultState'
+        - $ref: '#/components/schemas/StreamflowResultHypermedia'
+
+    # List of streamflow results
+
+    StreamflowResultListItem:
+      description: Item in list of streamflow results
+      type: object
+      allOf:
+        - type: object
+          properties:
+            uri:
+              type: string
+              description: URI of streamflow result
+              example: 'http://apis.paccifcclimate.org/streamflow/results/6'
+        - $ref: '#/components/schemas/StreamflowResultState'
+
+    StreamflowResultList:
+      description: List of streamflow results
+      type: array
+      items:
+        $ref: '#/components/schemas/StreamflowResultListItem'
+      example:
+        - uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+          status: ready
+          hydromodel_output_id: 4
+          cell_x: 27
+          cell_y: 33
+        - uri: 'http://apis.paccifcclimate.org/streamflow/results/7'
+          status: ready
+          hydromodel_output_id: 5
+          cell_x: 18
+          cell_y: 99
+
+
+    # Streamflow result data
+
+    StreamflowResultAnnualCycle:
+      description: Annual cycle time series for a streamflow result set
+      $ref: '#/components/schemas/Timeseries'
+
+    StreamflowResultAnnualMax:
+      description: Annual maximum time series for a streamflow result set
+      $ref: '#/components/schemas/Timeseries'
+
+    StreamflowResultAnnualMean:
+      description: Annual mean time series for a streamflow result set
+      $ref: '#/components/schemas/Timeseries'
+
+
+    ###
+    ### Template schemas for collections of things
+
+    ### Individual things
+
+    ThingStateNew:
+      description: Defines a new thing. Contains only state directly settable by user.
+      type: object
+      properties:
+        prop:
+          type: number
+          example: -123.5
+
+    ThingState:
+      description: State for a thing. Contains complete state.
+      allOf:
+        - type: object
+          properties:
+            id:
+              type: integer
+              example: 5
+            etc:
+              type: string
+        - $ref: '#/components/schemas/ThingStateNew'
+
+    ThingHypermedia:
+      description: Hypermedia for a thing
+      type: object
+      properties:
+        links:
+          allOf:
+            - $ref: '#/components/schemas/HypermediaLinkList'
+            - example:
+                - rel: 'self'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                - rel: 'http://apis.paccifcclimate.org/relations/streamflow/orders/cancel'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                - rel: 'http://apis.paccifcclimate.org/relations/streamflow/results/metadata'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+                - rel: 'http://apis.paccifcclimate.org/relations/streamflow/results/timeseries'
+                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/timeseries'
+
+    Thing:
+      description: Representation of a thing - state + hypermedia.
+      allOf:
+        - $ref: '#/components/schemas/ThingState'
+        - $ref: '#/components/schemas/ThingHypermedia'
+
+    # Lists (collections) of things
+
+    ThingListItem:
+      description: Representation of a single item in a list of things.
+      type: object
+      allOf:
+        - type: object
+          properties:
+            uri:
+              type: string
+              description: URI of thing
+        - $ref: '#/components/schemas/HypermediaLinkList'
+        - $ref: '#/components/schemas/ThingState'
+
+    ThingList:
+      description: List of things in collection.
+      type: array
+      items:
+        $ref: '#/components/schemas/ThingListItem'

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -429,6 +429,19 @@ components:
       items:
         $ref: '#/components/schemas/HypermediaLink'
 
+    TemporalBounds:
+      description: Metadata describing temporal bounds of a dataset.
+      type: object
+      properties:
+        start_date:
+          description: Date-time of first timestep in dataset (ISO 8601)
+          type: string
+          example: '2000-01-01'
+        end_date:
+          description: Date-time of last timestep in dataset (ISO 8601)
+          type: string
+          example: '2100-12-31'
+
     Timeseries:
       description: A time series, which is to say a set of values at specified times.
         Data points are (time[i], value[i]).
@@ -460,6 +473,7 @@ components:
 
     HydromodelOutputState:
       description: State for a hydromodel output. Contains complete state.
+      type: object
       allOf:
         - type: object
           properties:
@@ -479,9 +493,7 @@ components:
               type: number
               example: 2.5
               description: Size of grid cells in Y (latitude) direction.
-            etc:
-              type: string
-              example: ... more tbd ...
+        - $ref: '#/components/schemas/TemporalBounds'
 
     HydromodelOutputHypermedia:
       description: Hypermedia for a hydromodel output.
@@ -555,9 +567,17 @@ components:
         - uri: 'https://services.pacificclimate.org/hydromodel_output/3'
           model: "CanESM2"
           experiment: "rcp45"
+          cell_x_size: 3.75
+          cell_y_size: 2.5
+          start_date: '2000-01-01'
+          end_date: '2100-12-31'
         - uri: 'https://services.pacificclimate.org/hydromodel_output/4'
           model: "CanESM2"
           experiment: "rcp85"
+          cell_x_size: 3.75
+          cell_y_size: 2.5
+          start_date: '2000-01-01'
+          end_date: '2100-12-31'
 
     ### Streamflow orders
 
@@ -707,33 +727,24 @@ components:
     StreamflowResultState:
       description: State describing a streamflow result
       type: object
-      properties:
-        status:
-          type: string
-          enum: [processing, ready, removed]
-          example: ready
-        hydromodel_output_id:
-          $ref: '#/components/schemas/HydromodelOutputId'
-        cell_x:
-          description: x-index of streamflow cell
-          type: integer
-          example: 27
-        cell_y:
-          description: y-index of streamflow cell
-          type: integer
-          example: 33
-        start_date:
-          description: Date-time of first timestep in streamflow results (ISO 8601)
-          type: string
-          example: '2000-01-01'
-        end_date:
-          description: Date-time of last timestep in streamflow results (ISO 8601)
-          type: string
-          example: '2100-12-31'
-        time_resolution:
-          description: Interval between timesteps in streamflow results (ISO 8601 duration)
-          type: string
-          example: 'PD1'
+      allOf:
+        - type: object
+          properties:
+            status:
+              type: string
+              enum: [processing, ready, removed]
+              example: ready
+            hydromodel_output_id:
+              $ref: '#/components/schemas/HydromodelOutputId'
+            cell_x:
+              description: x-index of streamflow cell
+              type: integer
+              example: 27
+            cell_y:
+              description: y-index of streamflow cell
+              type: integer
+              example: 33
+        - $ref: '#/components/schemas/TemporalBounds'
 
     StreamflowResultHypermedia:
       type: object
@@ -785,11 +796,15 @@ components:
           hydromodel_output_id: 4
           cell_x: 27
           cell_y: 33
+          start_date: '2000-01-01'
+          end_date: '2100-12-31'
         - uri: 'https://services.pacificclimate.org/streamflow/results/7'
           status: ready
           hydromodel_output_id: 5
           cell_x: 18
           cell_y: 99
+          start_date: '2000-01-01'
+          end_date: '2100-12-31'
 
 
     # Streamflow result data

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -5,7 +5,7 @@ info:
   description: Web service providing resources necessary to support streamflow web app
 
 servers:
-  - url: http://services.pacificclimate.org
+  - url: https://services.pacificclimate.org
 
 tags:
   - name: Hydromodel outputs
@@ -492,9 +492,9 @@ components:
             - $ref: '#/components/schemas/HypermediaLinkList'
             - example:
                 - rel: 'self'
-                  uri: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+                  uri: 'https://services.pacificclimate.org/hydromodel_output/4'
                 - rel: 'bounds'
-                  uri: 'http://apis.paccifcclimate.org/hydromodel_output/4/bounds'
+                  uri: 'https://services.pacificclimate.org/hydromodel_output/4/bounds'
 
     HydromodelOutput:
       description: Full representation of a hydromodel output - state + hypermedia.
@@ -527,9 +527,9 @@ components:
                 - [-64.73, 32.31]
         links:
           - rel: 'self'
-            uri: 'http://apis.paccifcclimate.org/hydromodel_output/4/bounds'
+            uri: 'https://services.pacificclimate.org/hydromodel_output/4/bounds'
           - rel: 'hydromodel_output'
-            uri: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+            uri: 'https://services.pacificclimate.org/hydromodel_output/4'
 
     # Lists (collections) of hydromodel outputs
 
@@ -542,7 +542,7 @@ components:
             uri:
               type: string
               description: URI of hydromodel output
-              example: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+              example: 'https://services.pacificclimate.org/hydromodel_output/4'
         - $ref: '#/components/schemas/HypermediaLinkList'
         - $ref: '#/components/schemas/HydromodelOutputState'
 
@@ -552,10 +552,10 @@ components:
       items:
         $ref: '#/components/schemas/HydromodelOutputListItem'
       example:
-        - uri: 'http://apis.paccifcclimate.org/hydromodel_output/3'
+        - uri: 'https://services.pacificclimate.org/hydromodel_output/3'
           model: "CanESM2"
           experiment: "rcp45"
-        - uri: 'http://apis.paccifcclimate.org/hydromodel_output/4'
+        - uri: 'https://services.pacificclimate.org/hydromodel_output/4'
           model: "CanESM2"
           experiment: "rcp85"
 
@@ -626,11 +626,11 @@ components:
               address: example@uvic.ca
             links:
               - rel: 'self'
-                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                uri: 'https://services.pacificclimate.org/streamflow/orders/5'
               - rel: 'cancel'
-                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                uri: 'https://services.pacificclimate.org/streamflow/orders/5'
               - rel: 'hydromodel_output'
-                uri: 'http://apis.paccifcclimate.org/hydromodel_outputs/4'
+                uri: 'https://services.pacificclimate.org/hydromodel_outputs/4'
 
     StreamflowOrderGeneric:
       description: Representation of a generic streamflow order.
@@ -651,19 +651,19 @@ components:
               address: example@uvic.ca
             links:
               - rel: 'self'
-                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                uri: 'https://services.pacificclimate.org/streamflow/orders/5'
               - rel: 'cancel'
-                uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+                uri: 'https://services.pacificclimate.org/streamflow/orders/5'
               - rel: 'hydromodel_output'
-                uri: 'http://apis.paccifcclimate.org/hydromodel_outputs/4'
+                uri: 'https://services.pacificclimate.org/hydromodel_outputs/4'
               - rel: 'results/metadata'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6'
               - rel: 'results/annual-max'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-max'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-max'
               - rel: 'results/annual-mean'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-mean'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-mean'
               - rel: 'results/annual-cycle'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-cycle'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle'
 
     # List of streamflow orders
 
@@ -676,7 +676,7 @@ components:
             uri:
               type: string
               description: URI of streamflow order
-              example: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+              example: 'https://services.pacificclimate.org/streamflow/orders/5'
         - $ref: '#/components/schemas/StreamflowOrderState'
 
     StreamflowOrderList:
@@ -685,14 +685,14 @@ components:
       items:
         $ref: '#/components/schemas/StreamflowOrderListItem'
       example:
-        - uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
+        - uri: 'https://services.pacificclimate.org/streamflow/orders/5'
           hydromodel_output_id: 4
           longitude: -123.5
           latitude: 48.5
           notification:
             method: email
             address: abc@example.ca
-        - uri: 'http://apis.paccifcclimate.org/streamflow/orders/6'
+        - uri: 'https://services.pacificclimate.org/streamflow/orders/6'
           hydromodel_output_id: 5
           longitude: -120.0
           latitude: 50.2
@@ -743,15 +743,15 @@ components:
             - $ref: '#/components/schemas/HypermediaLinkList'
             - example:
               - rel: 'self'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6'
               - rel: 'deprecate'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6'
               - rel: 'annual-cycle'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-cycle'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-cycle'
               - rel: 'annual-max'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-max'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-max'
               - rel: 'annual-mean'
-                uri: 'http://apis.paccifcclimate.org/streamflow/results/6/annual-mean'
+                uri: 'https://services.pacificclimate.org/streamflow/results/6/annual-mean'
 
     StreamflowResult:
       description: Metadata and hyperlinks for a single streamflow result
@@ -771,7 +771,7 @@ components:
             uri:
               type: string
               description: URI of streamflow result
-              example: 'http://apis.paccifcclimate.org/streamflow/results/6'
+              example: 'https://services.pacificclimate.org/streamflow/results/6'
         - $ref: '#/components/schemas/StreamflowResultState'
 
     StreamflowResultList:
@@ -780,12 +780,12 @@ components:
       items:
         $ref: '#/components/schemas/StreamflowResultListItem'
       example:
-        - uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
+        - uri: 'https://services.pacificclimate.org/streamflow/results/6'
           status: ready
           hydromodel_output_id: 4
           cell_x: 27
           cell_y: 33
-        - uri: 'http://apis.paccifcclimate.org/streamflow/results/7'
+        - uri: 'https://services.pacificclimate.org/streamflow/results/7'
           status: ready
           hydromodel_output_id: 5
           cell_x: 18
@@ -841,13 +841,13 @@ components:
             - $ref: '#/components/schemas/HypermediaLinkList'
             - example:
                 - rel: 'self'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
-                - rel: 'http://apis.paccifcclimate.org/relations/streamflow/orders/cancel'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/orders/5'
-                - rel: 'http://apis.paccifcclimate.org/relations/streamflow/results/metadata'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6'
-                - rel: 'http://apis.paccifcclimate.org/relations/streamflow/results/timeseries'
-                  uri: 'http://apis.paccifcclimate.org/streamflow/results/6/timeseries'
+                  uri: 'https://services.pacificclimate.org/streamflow/orders/5'
+                - rel: 'https://services.pacificclimate.org/relations/streamflow/orders/cancel'
+                  uri: 'https://services.pacificclimate.org/streamflow/orders/5'
+                - rel: 'https://services.pacificclimate.org/relations/streamflow/results/metadata'
+                  uri: 'https://services.pacificclimate.org/streamflow/results/6'
+                - rel: 'https://services.pacificclimate.org/relations/streamflow/results/timeseries'
+                  uri: 'https://services.pacificclimate.org/streamflow/results/6/timeseries'
 
     Thing:
       description: Representation of a thing - state + hypermedia.

--- a/streamflow-api.yaml
+++ b/streamflow-api.yaml
@@ -800,26 +800,16 @@ components:
             cell_y:
               description: y coordinate (longitude) of cell centre
               type: number
-            cell_x_index:
-              description: x-index of streamflow cell
-              type: integer
-            cell_y_index:
-              description: y-index of streamflow cell
-              type: integer
           required:
             - status
             - hydromodel_output_id
             - cell_x
             - cell_y
-            - cell_x_index
-            - cell_y_index
           example:
             status: ready
             hydromodel_output_id: 4
             cell_x: -118.7
             cell_y: 54.25
-            cell_x_index: 27
-            cell_y_index: 33
         - $ref: '#/components/schemas/GridCellSize'
         - $ref: '#/components/schemas/TemporalBounds'
 
@@ -866,8 +856,6 @@ components:
           cell_y_size: 2.5
           cell_x: -118.7
           cell_y: 54.2
-          cell_x_index: 27
-          cell_y_index: 33
           start_date: '2000-01-01'
           end_date: '2100-12-31'
         - uri: 'https://services.pacificclimate.org/streamflow/results/7'
@@ -877,8 +865,6 @@ components:
           cell_y_size: 2.5
           cell_x: -123.7
           cell_y: 60.8
-          cell_x_index: 18
-          cell_y_index: 99
           start_date: '2000-01-01'
           end_date: '2100-12-31'
 


### PR DESCRIPTION
Resolves #86 

Updated from initial draft circulated a few weeks ago. Updates:

- Base for streamflow-related endpoints: `services.pacificclimate.org/streamflow/` (not routed_streamflows).
- All resource names plural (e.g., `/streamflow/orders`, not `/streamflow/order`).
- All response bodies are fully fleshed out (or should be).
- Consistent use of hyperlinks in all response bodies.
- Hyperlink `ref` properties are abbreviated (e.g., 'cancel') instead of long-form hyperlink.
- Full factoring of commonalities in schemas, parameters, responses, etc.

Notes: 

- The [Streamflow Architecture document](https://pcic.uvic.ca/confluence/display/CSG/Streamflow+Architecture+II) is a key resource to understanding the lifecycles of Orders and Results. 
- See also [Streamflow API Design discussion](https://pcic.uvic.ca/confluence/display/CSG/Streamflow+API+Design).