### PR TITLE
Fix cell_methods filter

### DIFF
--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -99,6 +99,20 @@ def mean_datetime(datetimes):
 def validate_cell_method(cell_method):
     return cell_method in ('mean', 'standard_deviation')
 
+def find_matching_cell_methods(cell_methods, target_method):
+    def filter_on_method(cell_method, target_method):
+        pattern = r'time:[a-z\s]*time:\s+{}\s+over\s+(days|years)'.format(target_method)
+        return re.fullmatch(pattern, cell_method)
+
+    if target_method == 'mean':
+        return [cell_method for cell_method in cell_methods
+                if filter_on_method(cell_method, target_method) or
+                   (not filter_on_method(cell_method, target_method) and
+                    not filter_on_method(cell_method, 'standard_deviation'))]
+    else:
+        return [cell_method for cell_method in cell_methods
+                if filter_on_method(cell_method, target_method)]
+
 def search_for_unique_ids(sesh, ensemble_name='ce', model='', emission='',
                           variable='', time=0, timescale='', cell_method='mean'):
     if not validate_cell_method(cell_method):
@@ -106,12 +120,8 @@ def search_for_unique_ids(sesh, ensemble_name='ce', model='', emission='',
 
     cell_methods = sesh.query(mm.DataFileVariable.variable_cell_methods)\
                     .distinct(mm.DataFileVariable.variable_cell_methods).all()
-    pattern = {
-        'standard_deviation': r'time:[a-z\s]*time:\s+standard_deviation\s+over\s+(days|years)',
-        'mean': r'time:[a-z\s]*\s+(time:\s+mean\s+over\s+(days|years))?'
-    }[cell_method]
 
-    matching_cell_methods = [r[0] for r in cell_methods if re.match(pattern, r[0])]
+    matching_cell_methods = find_matching_cell_methods([r[0] for r in cell_methods], cell_method)
 
     query = sesh.query(mm.DataFile.unique_id)\
             .distinct(mm.DataFile.unique_id)\

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -104,6 +104,17 @@ def find_matching_cell_methods(cell_methods, target_method):
         pattern = r'time:[a-z\s]*time:\s+{}\s+over\s+(days|years)'.format(target_method)
         return re.fullmatch(pattern, cell_method)
 
+    # Older data sets were all climatological means and therefore the
+    # cell_method attribute never had to specify that they were such.  With the
+    # introduction of climatological standard deviation data sets the
+    # cell_method usage had to be updated such that we could differentiate
+    # between the different the data operations.  Thus any cell_method that
+    # doesn't match the updated version is considered to be a climatological
+    # mean.
+    #
+    # The conventions that were followed to create these cell_method attributes
+    # can be found here:
+    # http://cfconventions.org/cf-conventions/cf-conventions.html#cell-methods
     if target_method == 'mean':
         return [cell_method for cell_method in cell_methods
                 if filter_on_method(cell_method, target_method) or

--- a/ce/tests/test_api.py
+++ b/ce/tests/test_api.py
@@ -178,11 +178,11 @@ def test_stats(populateddb, polygon, unique_id, var_name):
 
 
 @pytest.mark.parametrize(('filters', 'keys'), (
-    ({'variable': 'tasmax'},
+    ({'variable': 'tasmax', 'cell_method': 'standard_deviation'},
      ('CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc', 'file2')),
     ({'variable': 'tasmax', 'model': 'BNU-ESM', 'cell_method': 'standard_deviation'},
      ['tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230']),
-    ({'variable': 'tasmax', 'timescale': 'seasonal'},
+    ({'variable': 'tasmax', 'timescale': 'seasonal', 'cell_method': 'standard_deviation'},
      ['tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230']),
     ({'variable': 'tasmin', 'model': 'BNU-ESM', 'cell_method': 'mean'},
      ['tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230']),


### PR DESCRIPTION
The `cell_methods` filter I implemented in PR #96 did not function as I intended.  It would grab `standard_deviation` data file ids while filtering for `mean` data file ids which was not a desirable behaviour.  The solution was to add some more structure to the logic of the filter.  Any climatological standard deviations will have an expected `cell_method` that we can regex for rather simply.  However the climatological means do not consistently use `cell_method` correctly.  To fix this I added a pattern to match for the correct `cell_method` and ignore other cases.  These ignored cases would be checked against the filter for `standard_deviation` and if they did not match they would be considered means.  This resolves issue #98.