### PR TITLE
Pin netCDF4 at <1.4 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'modelmeta==0.2.0',
         'shapely>=1.6',
         'numpy',
-        'netcdf4',
+        'netcdf4<1.4',
         'python-dateutil',
         'GDAL',
         'rasterio',


### PR DESCRIPTION
According to the [netCDF4 changelog for version 1.4.0](https://github.com/Unidata/netcdf4-python/blob/86f7f4f857422f885dddb087aa985fe9a6096686/Changelog#L99):

```
 * always return masked array by default, even if there are no
   masked values (too surprising to get ndarray or MaskedArray depending
   on slice, issue #785).
```
Previous to version 1.4 of netCDF4, data would be returned as a masked array only if some of it was missing / masked. The backend's processing of latitude and longitude assume that these variables are _not_ masked arrays, so the backend does not work correctly with versions of netCDF4 >= 1.4. For example, [make_mask_grid_key()](https://github.com/pacificclimate/climate-explorer-backend/blob/master/ce/api/geo.py#L137)  expects longitude[0] to be type np.float, which is true if longitude is an ndarray, but not if it is a maskedarray.

This PR pins netCDF4 in setup.py ensuring that when the backend is used as a module for another system, like [plan2adapt](https://github.com/pacificclimate/p2a-rule-engine), it uses a version of netCDF4 < 1.4. NetCDF4 is already pinned in requirements.txt for standalone builds.