### PR TITLE
Drop support for Python <3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: bionic
 sudo: false
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
 addons:


### PR DESCRIPTION
Resolves #115 