### PR TITLE
Allow users to skip calculations they don't require

### DIFF
--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -17,6 +17,11 @@ def multistats(sesh, ensemble_name='ce_files', model='', emission='', time=0,
     It starts by searching for all of the data files for the provided
     variable and will filter according to the model and emission
     parameters.
+    
+    To (slightly) improve performance, a caller may request only a subset
+    of statistics be calculated by passing in parameters (mean, stdev,
+    min, max, median) corresponding to the statistics desired. If no
+    subset is specified, all five statistics will be calculated and returned.
 
     Args:
         sesh (sqlalchemy.orm.session.Session): A database Session object

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -5,7 +5,8 @@ from ce.api.stats import stats
 from ce.api.util import search_for_unique_ids
 
 def multistats(sesh, ensemble_name='ce_files', model='', emission='', time=0,
-               area=None, variable='', timescale='', cell_method='mean'):
+               area=None, variable='', timescale='', cell_method='mean',
+               mean=None, stdev=None, min=None, max=None, median=None):
     '''Request and calculate statistics for multiple models or scenarios
 
     There are some cases for which one may want to get a set of
@@ -83,6 +84,7 @@ def multistats(sesh, ensemble_name='ce_files', model='', emission='', time=0,
     ids = search_for_unique_ids(sesh, ensemble_name, model, emission, variable,
                                 time, timescale, cell_method)
     return {
-        id_: stats(sesh, id_, time, area, variable)[id_]
+        id_: stats(sesh, id_, time, area, variable,
+                   mean, stdev, min, max, median)[id_]
         for id_ in ids
     }

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -29,6 +29,12 @@ def stats(sesh, id_, time, area, variable,
 
     The stats call may only be called for a single data file and single
     variable per invocation.
+    
+    To (slightly) improve performance, if only a subset of statistics
+    are needed, the querent may optionally provide parameters
+    corresponding to the statistical subset needed (mean, stdev, min,
+    max, and/or median) may be supplied. If no subset parameters are
+    received, all five statistics will be returned.
 
     Args:
         sesh (sqlalchemy.orm.session.Session): A database Session object

--- a/ce/tests/api/test_stats.py
+++ b/ce/tests/api/test_stats.py
@@ -52,3 +52,33 @@ def test_stats_bad_params(populateddb, unique_id, var):
 def test_stats_bad_id(populateddb):
     rv = stats(populateddb.session, 'id-does-not-exist', None, None, None)
     assert rv == {}
+
+@pytest.mark.parametrize('mean', ['', None])
+@pytest.mark.parametrize('median', ['', None])
+@pytest.mark.parametrize('max', ['', None])
+def test_stats_subset(populateddb, mean, median, max):
+    sesh = populateddb.session
+    unique_id = 'tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230'
+    
+    #default all-statistics request for comparison
+    allstats = stats(sesh, unique_id, None, None, 'tasmax')
+    
+    #subset request
+    subset = stats(sesh, unique_id, None, None, 'tasmax', mean=mean, median=median, max=max)
+    
+    if mean is None and median is None and max is None:
+        assert allstats == subset
+    else:
+        for m in ['mean', 'median', 'max']:
+            if eval(m) is None:
+                assert m not in subset[unique_id]
+            else:
+                assert m in subset[unique_id]
+                assert allstats[unique_id][m] == subset[unique_id][m]
+            for m in ['min', 'stdev']:
+                assert m not in subset[unique_id]
+            for m in ['ncells', 'time', 'units', 'modtime']:
+                assert m in subset[unique_id]
+                assert subset[unique_id][m] == allstats[unique_id][m]
+        
+    


### PR DESCRIPTION
This PR adds optional parameters to the `multistats` and `stats` queries to allow a user to request a subset of the statistics normally provided by these queries. This goal of this change is to allow a minor performance improvement by skipping unnecessary calculations (https://github.com/pacificclimate/p2a-rule-engine/issues/3), but since most of the execution time is spent reading the datafile, improvements via this method are limited.

The optional parameters are named `median`, `mean`, `max`, `min`, and `stdev`, and are passed without arguments, for example:

```
http://server:port/api/multistats&ensemble_name=ce_files&model=PCIC12&variable=cdd
&emission=historical,rcp85&time=2&timescale=seasonal&mean&median
```
would return only the mean and median values, skipping calculation and return of `max`, `min` and `stdev`.

`ncells`, `units`, `time`, and `modtime` are always returned.

A demo docker is [here](http://docker-dev01.pcic.uvic.ca:30033/api/multistats?ensemble_name=ce_files&model=PCIC12&variable=cdd&emission=historical,rcp85&time=2&timescale=seasonal&mean).

Resolves #119 