### PR TITLE
Update SQLAlchemy to version 1.3.17 and fix multimeta tests

### DIFF
--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -74,14 +74,14 @@ def multimeta(sesh, ensemble_name="ce_files", model=""):
             TimeSet.end_date,
             DataFile.index_time,
         )
-        .join(Run)
+        .join(Run, Run.id == DataFile.run_id)
         .join(Model)
         .join(Emission)
-        .join(DataFileVariable)
+        .join(DataFileVariable, DataFileVariable.variable_alias_id == VariableAlias.id)
         .join(EnsembleDataFileVariables)
         .join(Ensemble)
         .join(VariableAlias)
-        .join(TimeSet)
+        .join(TimeSet, TimeSet.id == DataFile.time_set_id)
         .filter(Ensemble.name == ensemble_name)
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy
 netcdf4==1.3
 GDAL~=3.0
 rasterio~=1.1
-sqlalchemy==1.2.18
+sqlalchemy==1.3.17
 contexttimer==0.3.3
 
 # For documentation


### PR DESCRIPTION
After upgrading SQLAlchemy to version 1.3.17, the tests that use `multimeta.py` failed due to `Can't determine which FROM clause to join from, there are multiple FROMS which can join to this entity` errors. These were fixed by specifying on which attributes the tables should join wherever there was an ambiguity.