### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    contianer: pcic/geospatial-python:gdal3
+    container: pcic/geospatial-python:gdal3
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,24 @@
+name: CI Tests
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt -r test_requirements.txt
+        pip install .
+        python setup.py build_sphinx
+    - name: Test with pytest
+      run: |
+        pytest -v --flake8

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     container: pcic/geospatial-python:gdal3
 
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,16 +6,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    contianer: pcic/geospatial-python:gdal3
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt -r test_requirements.txt
         pip install .
         python setup.py build_sphinx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   docker-publish:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,35 @@
+name: Docker Publishing
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - '*'
+
+jobs:
+  docker-publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - run: git pull --unshallow
+    - name: Get Branch
+      uses: nelonoel/branch-name@v1
+    - name: Get Tag
+      uses: olegtarasov/get-tag@v2
+    - name: Set env vars for build
+      run: |
+        echo ::set-env name=BRANCH::$(echo ${BRANCH_NAME})
+        echo ::set-env name=TAG::$(echo ${GIT_TAG_NAME})
+    - name: Run commitish script
+      run: ./generate-commitish.sh
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: pcic/climate-explorer-frontend
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "${{ env.BRANCH }},${{ env.TAG }}"
+        buildargs: ${REACT_APP_CE_CURRENT_VERSION}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,11 @@ name: Docker Publishing
 
 on:
   push:
-    tags:
-      - '*'
     branches:
       - '*'
+  release:
+    types:
+      - created
 
 jobs:
   docker-publish:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,8 +23,6 @@ jobs:
       run: |
         echo ::set-env name=BRANCH::$(echo ${BRANCH_NAME})
         echo ::set-env name=TAG::$(echo ${GIT_TAG_NAME})
-    - name: Run commitish script
-      run: ./generate-commitish.sh
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -32,4 +30,3 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         tags: "${{ env.BRANCH }},${{ env.TAG }}"
-        buildargs: ${REACT_APP_CE_CURRENT_VERSION}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: pcic/climate-explorer-frontend
+        name: pcic/climate-explorer-backend
         username: ${{ secrets.pcicdevops_at_dockerhub_username }}
         password: ${{ secrets.pcicdevops_at_dockerhub_password }}
         tags: "${{ env.BRANCH }},${{ env.TAG }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,6 @@ jobs:
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: pcic/climate-explorer-frontend
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.pcicdevops_at_dockerhub_username }}
+        password: ${{ secrets.pcicdevops_at_dockerhub_password }}
         tags: "${{ env.BRANCH }},${{ env.TAG }}"

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,30 @@
+name: Image Scan
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  anchore:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait for image to be published
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: docker-publish
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get Branch Name
+        uses: nelonoel/branch-name@v1
+      - name: Set Branch Name to Environment Variable
+        run: echo ::set-env name=TAG::$(echo ${BRANCH_NAME})
+      - name: Scan Image
+        uses: anchore/scan-action@master
+        with:
+          image-reference: "pcic/climate-explorer-frontend:${{ env.TAG }}"
+          fail-build: true
+        if: steps.wait-for-build.outputs.conclusion == 'success'

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   anchore:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Wait for image to be published

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -18,13 +18,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: docker-publish
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Get Branch Name
-        uses: nelonoel/branch-name@v1
-      - name: Set Branch Name to Environment Variable
-        run: echo ::set-env name=TAG::$(echo ${BRANCH_NAME})
       - name: Scan Image
         uses: anchore/scan-action@master
         with:
-          image-reference: "pcic/climate-explorer-frontend:${{ env.TAG }}"
+          image-reference: "pcic/climate-explorer-backend:${{ github.event.pull_request.head.ref }}"
           fail-build: true
         if: steps.wait-for-build.outputs.conclusion == 'success'


### PR DESCRIPTION
Adds github actions to the repo.  The workflows will take over the responsibilities of Jenkins and Travis which are:
- run python test suite (on all pushes)
- build and publish docker image (on all branches + on tag creation)
- anchore scan docker image (on PRs targeting `master`)

I do not have permission to access the webhooks in this repo but Travis and Jenkins need to be deactivated.