### PR TITLE
Upgrade python-netCDF4 requirement to 1.5

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
+        pip install -U pip wheel
         pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt -r test_requirements.txt
         pip install .
         python setup.py build_sphinx

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
+        apt install libxml2-dev libxslt1-dev
         pip install -U pip wheel
         pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt -r test_requirements.txt
         pip install .

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        apt install libxml2-dev libxslt1-dev
+        apk add libxml2-dev libxslt-dev
         pip install -U pip wheel
         pip install -i https://pypi.pacificclimate.org/simple -r requirements.txt -r test_requirements.txt
         pip install .

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -178,12 +178,14 @@ def make_mask_grid_key(nc, fname, poly, variable):
     and min / max / number of steps for both latitutde and longitude.
     Assumes a regular grid.
     """
-    latsteps = nc.variables["lat"].shape[0]
-    latmin = nc.variables["lat"][0]
-    latmax = nc.variables["lat"][latsteps - 1]
-    lonsteps = nc.variables["lon"].shape[0]
-    lonmin = nc.variables["lon"][0]
-    lonmax = nc.variables["lon"][lonsteps - 1]
+    lat = nc.variables["lat"]
+    lon = nc.variables["lon"]
+    latsteps = lat.shape[0]
+    latmin = np.min(lat)
+    latmax = np.max(lat)
+    lonsteps = lon.shape[0]
+    lonmin = np.min(lon)
+    lonmax = np.max(lon)
     wkt = dumps(poly)  # dict-style geoJSON can't be hashed
     return (wkt, latmin, latmax, latsteps, lonmin, lonmax, lonsteps)
 

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -63,6 +63,7 @@ def open_nc(fname):
 
     try:
         nc = Dataset(fname, "r")
+        nc.set_always_mask(False)
         yield nc
     finally:
         nc.close()

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -20,7 +20,7 @@ from modelmeta.v2 import (
     TimeSet,
     ClimatologicalTime,
     DataFile,
-    DataFileVariable,
+    DataFileVariableGridded,
 )
 from flask_sqlalchemy import SQLAlchemy
 from netCDF4 import Dataset
@@ -298,7 +298,7 @@ def populateddb(cleandb,):
             "pr": "time: mean time: mean over days",
             "flow_direction": "foo",
         }[var_name]
-        return DataFileVariable(
+        return DataFileVariableGridded(
             file=file,
             netcdf_variable_name=var_name,
             range_min=0,
@@ -518,7 +518,7 @@ def multitime_db(cleandb,):
     )
 
     dfvs = [
-        DataFileVariable(
+        DataFileVariableGridded(
             netcdf_variable_name="tasmax",
             range_min=0,
             range_max=50,

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -7,7 +7,7 @@ WORKDIR /app
 
 RUN pip3 install -i https://pypi.pacificclimate.org/simple -r requirements.txt
 RUN pip3 install gunicorn
-RUN python3 ./setup.py install
+RUN pip3 install .
 
 EXPOSE 8000
 

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,6 +1,8 @@
 FROM pcic/geospatial-python:gdal3
 
 RUN apk add postgresql-dev libxml2-dev libxslt-dev
+# Fix https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10878
+RUN apk upgrade perl
 
 ADD . /app
 WORKDIR /app

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,6 +1,6 @@
 FROM pcic/geospatial-python:gdal3
 
-RUN apk add postgresql-dev
+RUN apk add postgresql-dev libxml2-dev libxslt-dev
 
 ADD . /app
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Cors
 modelmeta==0.2.0
 shapely>=1.6
 numpy
-netcdf4==1.3
+netCDF4==1.5.*
 GDAL~=3.0
 rasterio~=1.1
 sqlalchemy==1.3.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask
 Flask-SQLAlchemy
 Flask-Cors
-modelmeta==0.2.0
+modelmeta==1.0.0
 shapely>=1.6
 numpy
 netCDF4==1.5.*

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "modelmeta==0.2.0",
         "shapely>=1.6",
         "numpy",
-        "netcdf4<1.4",
+        "netCDF4",
         "python-dateutil",
         "GDAL",
         "rasterio",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Flask-SQLAlchemy",
         "Flask-Cors",
         "Flask-Cache",
-        "modelmeta==0.2.0",
+        "modelmeta>=1.0.0",
         "shapely>=1.6",
         "numpy",
         "netCDF4",


### PR DESCRIPTION
The `python-netCDF4` library has released a couple of minor versions, and I think it's time to circle back on the decision that we made in #97 

This PR:

+ adds a test for our `geo` module that ensures that the array results that come back from a netCDF file are in fact scalars and hashable (which I believe was the original problem for the P2A rules engine)
+ upgrades `netCDF4` to 1.5 to demostrate the tests (expectedly) *failing*, and then
+ implements the fix

You can see the results form each step [in the Actions output](https://github.com/pacificclimate/climate-explorer-backend/actions?query=branch%3Aupgrade-netCDF4).

I'm pretty sure that it works well, but I'm happy to have another couple pair of eyes on this, just in case.