### PR TITLE
Provide filepath in /metadata and /multimeta responses

### DIFF
--- a/ce/api/metadata.py
+++ b/ce/api/metadata.py
@@ -36,6 +36,7 @@ def metadata(sesh, model_id):
             {
                 'tmax_monClim_PRISM_historical_run1_198101-201012':
                 {
+                    'filepath': '/storage/data/projects/blah/blah/tmax_monClim_PRISM_historical_run1_198101-201012.nc',
                     'institution': 'Pacific Climate Impacts Consortium',
                     'model_id': 'BCSD+ANUSPLIN300+CCSM4',
                     'model_name': 'CCSM4 GCM data downscaled to '
@@ -98,6 +99,7 @@ def metadata(sesh, model_id):
 
     return {
         model_id: {
+            "filepath": data_file.filename,
             "institution": model.organization,
             "model_id": model.short_name,
             "model_name": model.long_name,

--- a/ce/api/metadata.py
+++ b/ce/api/metadata.py
@@ -106,26 +106,22 @@ def metadata(sesh, model_id, extras=""):
 
     # Time are given null values if timeset is absent.
     timeset = data_file.timeset
-    time_values = {
-        "times": {
-            time.time_idx: time.timestep for time in timeset.times
-        },
-        "timescale": timeset.time_resolution,
-        "multi_year_mean": timeset.multi_year_mean,
-        "start_date": timeset.start_date,
-        "end_date": timeset.end_date,
-    } if timeset else {
-        "times": {},
-        "timescale": None,
-        "multi_year_mean": None,
-        "start_date": None,
-        "end_date": None,
-    }
-
-    return {
-        model_id: {
-            **base_values,
-            **requested_extra_values,
-            **time_values,
+    time_values = (
+        {
+            "times": {time.time_idx: time.timestep for time in timeset.times},
+            "timescale": timeset.time_resolution,
+            "multi_year_mean": timeset.multi_year_mean,
+            "start_date": timeset.start_date,
+            "end_date": timeset.end_date,
         }
-    }
+        if timeset
+        else {
+            "times": {},
+            "timescale": None,
+            "multi_year_mean": None,
+            "start_date": None,
+            "end_date": None,
+        }
+    )
+
+    return {model_id: {**base_values, **requested_extra_values, **time_values,}}

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -28,6 +28,10 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras=""):
 
         model (str): Short name for some climate model (e.g "CGCM3")
 
+        extras (str): Comma-separated list of extra fields to be included in
+            response. Currently responds to fields:
+                "filepath": in each dictionary item, filepath of data file
+
     Returns:
         A dictionary keyed by unique_id for all unique_ids in the
         requested model/ensemble. The value is delegated to the metadata call

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -35,24 +35,26 @@ def multimeta(sesh, ensemble_name="ce_files", model=""):
         For example::
 
           {
-          pr_day_BCCAQ-ANUSPLIN300-MRI-CGCM3_historical-rcp45_r1i1p1_19500101-21001231:
-              {
-              institution: "PCIC",
-              model_id: "BCCAQ+ANUSPLIN300+MRI-CGCM3",
-              model_name: "",
-              experiment: "historical+rcp45",
-              variables:
-                  {
-                  "pr": "Precipitation"
-                  },
-              ensemble_member: "r1i1p1",
-              timescale: "monthly",
-              multi_year_mean: false,
-              start_date: datetime.datetime(1950, 1, 1, 0, 0),
-              end_date: datetime.datetime(2100, 12, 31, 0, 0),
-              modtime: datetime.datetime(2010, 1, 1, 17, 30, 4)
+              'pr_day_BCCAQ-ANUSPLIN300-MRI-CGCM3_historical-rcp45_r1i1p1_19500101-21001231': {
+                  'filepath': '/storage/data/projects/blah/blah/pr_day_BCCAQ-ANUSPLIN300-MRI-CGCM3_historical-rcp45_r1i1p1_19500101-21001231.nc',
+                  'institution': 'PCIC',
+                  'model_id': 'BCCAQ+ANUSPLIN300+MRI-CGCM3',
+                  'model_name': '',
+                  'experiment': 'historical+rcp45',
+                  'variables':
+                      {
+                        'pr': 'Precipitation'
+                      },
+                  'ensemble_member': 'r1i1p1',
+                  'timescale': 'monthly',
+                  'multi_year_mean': false,
+                  'start_date': datetime.datetime(1950, 1, 1, 0, 0),
+                  'end_date': datetime.datetime(2100, 12, 31, 0, 0),
+                  'modtime': datetime.datetime(2010, 1, 1, 17, 30, 4)
               },
-          unique_id2:
+              'unique_id2': {
+                  ...
+              },
               ...
           }
 
@@ -61,6 +63,7 @@ def multimeta(sesh, ensemble_name="ce_files", model=""):
     q = (
         sesh.query(
             DataFile.unique_id,
+            DataFile.filename,
             Model.organization,
             Model.short_name,
             Model.long_name,
@@ -100,6 +103,7 @@ def multimeta(sesh, ensemble_name="ce_files", model=""):
     # circa release 1.1
     for (
         id_,
+        filepath,
         org,
         model_short,
         model_long,
@@ -115,6 +119,7 @@ def multimeta(sesh, ensemble_name="ce_files", model=""):
     ) in results:
         if id_ not in rv:
             rv[id_] = {
+                "filepath": filepath,
                 "institution": org,
                 "model_id": model_short,
                 "model_name": model_long,

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -121,9 +121,11 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras=""):
     allowable_extra_attribute_names = """
             filepath
         """.split()
-    extra_attribute_names = [
-        name for name in extras.split(",") if name in allowable_extra_attribute_names
-    ] if extras is not None and extras != "" else []
+    extra_attribute_names = (
+        [name for name in extras.split(",") if name in allowable_extra_attribute_names]
+        if extras is not None and extras != ""
+        else []
+    )
 
     simple_attribute_names = base_attribute_names + extra_attribute_names
 
@@ -135,7 +137,8 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras=""):
                 name: getattr(result, name) for name in simple_attribute_names
             }
             rv[unique_id]["variables"] = {}
-        rv[unique_id]["variables"][result.netcdf_variable_name] = \
-            result.variable_long_name
-        
+        rv[unique_id]["variables"][
+            result.netcdf_variable_name
+        ] = result.variable_long_name
+
     return rv

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -6,7 +6,7 @@ from modelmeta import DataFileVariableGridded, VariableAlias, TimeSet
 from modelmeta import EnsembleDataFileVariables, Ensemble
 
 
-def multimeta(sesh, ensemble_name="ce_files", model=""):
+def multimeta(sesh, ensemble_name="ce_files", model="", extras=""):
     """Retrieve metadata for all data files in an ensemble
 
     The ``multimeta`` API call is available to retrieve summarized
@@ -62,20 +62,20 @@ def multimeta(sesh, ensemble_name="ce_files", model=""):
 
     q = (
         sesh.query(
-            DataFile.unique_id,
-            DataFile.filename,
-            Model.organization,
-            Model.short_name,
-            Model.long_name,
-            Emission.short_name,
-            Run.name,
-            DataFileVariableGridded.netcdf_variable_name,
-            VariableAlias.long_name,
-            TimeSet.time_resolution,
-            TimeSet.multi_year_mean,
-            TimeSet.start_date,
-            TimeSet.end_date,
-            DataFile.index_time,
+            DataFile.unique_id.label("unique_id"),
+            DataFile.filename.label("filepath"),
+            Model.organization.label("institution"),
+            Model.short_name.label("model_id"),
+            Model.long_name.label("model_name"),
+            Emission.short_name.label("experiment"),
+            Run.name.label("ensemble_member"),
+            DataFileVariableGridded.netcdf_variable_name.label("netcdf_variable_name"),
+            VariableAlias.long_name.label("variable_long_name"),
+            TimeSet.time_resolution.label("timescale"),
+            TimeSet.multi_year_mean.label("multi_year_mean"),
+            TimeSet.start_date.label("start_date"),
+            TimeSet.end_date.label("end_date"),
+            DataFile.index_time.label("modtime"),
         )
         .join(Run, Run.id == DataFile.run_id)
         .join(Model)
@@ -95,44 +95,43 @@ def multimeta(sesh, ensemble_name="ce_files", model=""):
     if model:
         q = q.filter(Model.short_name == model)
 
-    rv = {}
     results = q.all()
 
     # FIXME: aggregation of the variables can be done in database with the
     # array_agg() function. Change this when SQLAlchemy supports it
     # circa release 1.1
-    for (
-        id_,
-        filepath,
-        org,
-        model_short,
-        model_long,
-        emission,
-        run,
-        var,
-        long_var,
-        timescale,
-        multi_year_mean,
-        start_date,
-        end_date,
-        modtime,
-    ) in results:
-        if id_ not in rv:
-            rv[id_] = {
-                "filepath": filepath,
-                "institution": org,
-                "model_id": model_short,
-                "model_name": model_long,
-                "experiment": emission,
-                "variables": {var: long_var},
-                "ensemble_member": run,
-                "timescale": timescale,
-                "multi_year_mean": multi_year_mean,
-                "start_date": start_date,
-                "end_date": end_date,
-                "modtime": modtime,
-            }
-        else:
-            rv[id_]["variables"][var] = long_var
 
+    base_attribute_names = """
+            institution
+            model_id
+            model_name
+            experiment
+            ensemble_member
+            timescale
+            multi_year_mean
+            start_date
+            end_date
+            modtime        
+        """.split()
+
+    allowable_extra_attribute_names = """
+            filepath
+        """.split()
+    extra_attribute_names = [
+        name for name in extras.split(",") if name in allowable_extra_attribute_names
+    ] if extras is not None and extras != "" else []
+
+    simple_attribute_names = base_attribute_names + extra_attribute_names
+
+    rv = {}
+    for result in results:
+        unique_id = result.unique_id
+        if unique_id not in rv:
+            rv[unique_id] = {
+                name: getattr(result, name) for name in simple_attribute_names
+            }
+            rv[unique_id]["variables"] = {}
+        rv[unique_id]["variables"][result.netcdf_variable_name] = \
+            result.variable_long_name
+        
     return rv

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -11,39 +11,23 @@ from test_utils import check_dict_subset
 @pytest.mark.parametrize(
     "endpoint, query_params, expected",
     [
-        (
-            "stats",
-            {"id_": "", "time": "", "area": "", "variable": ""},
-            {},
-        ),
+        ("stats", {"id_": "", "time": "", "area": "", "variable": ""}, {},),
         (
             "data",
             {"model": "", "emission": "", "time": "0", "area": "", "variable": ""},
             {},
         ),
-        (
-            "timeseries",
-            {"id_": "", "area": "", "variable": ""},
-            {},
-        ),
-        (
-            "models",
-            {},
-            {},
-        ),
+        ("timeseries", {"id_": "", "area": "", "variable": ""}, {},),
+        ("models", {}, {},),
         (
             "metadata",
-            {
-                "model_id": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
-            },
+            {"model_id": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",},
             {
                 "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230": {
                     "institution": "BNU",
                     "model_id": "BNU-ESM",
                     "experiment": "historical",
-                    "variables": {
-                        "tasmax": "Daily Maximum Temperature"
-                    },
+                    "variables": {"tasmax": "Daily Maximum Temperature"},
                     "ensemble_member": "r1i1p1",
                     "times": {
                         "0": "1985-01-15T00:00:00Z",
@@ -57,12 +41,12 @@ from test_utils import check_dict_subset
                         "8": "1985-09-15T00:00:00Z",
                         "9": "1985-10-15T00:00:00Z",
                         "10": "1985-11-15T00:00:00Z",
-                        "11": "1985-12-15T00:00:00Z"
+                        "11": "1985-12-15T00:00:00Z",
                     },
                     "timescale": "monthly",
                     "multi_year_mean": True,
                     "start_date": "1971-01-01T00:00:00Z",
-                    "end_date": "2000-12-31T00:00:00Z"
+                    "end_date": "2000-12-31T00:00:00Z",
                 },
             },
         ),
@@ -94,9 +78,7 @@ from test_utils import check_dict_subset
                     "multi_year_mean": True,
                     "start_date": "1971-01-01T00:00:00Z",
                     "end_date": "2000-12-31T00:00:00Z",
-                    "variables": {
-                        "tasmax": "Daily Maximum Temperature",
-                    },
+                    "variables": {"tasmax": "Daily Maximum Temperature",},
                 },
             },
         ),
@@ -105,29 +87,20 @@ from test_utils import check_dict_subset
             {"ensemble_name": "ce", "model": "", "extras": "filepath"},
             {
                 "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
-                    "filepath": re.compile(r"CanESM2-rcp85-tasmax-r1i1p1-2010-2039\.nc"),
+                    "filepath": re.compile(
+                        r"CanESM2-rcp85-tasmax-r1i1p1-2010-2039\.nc"
+                    ),
                     "institution": "CCCMA",
                 },
             },
         ),
-        (
-            "lister",
-            {"model": ""},
-            {},
-        ),
-        (
-            "grid",
-            {"id_": ""},
-            {},
-        ),
+        ("lister", {"model": ""}, {},),
+        ("grid", {"id_": ""}, {},),
     ],
 )
 @pytest.mark.usefixtures("populateddb")
 def test_api_endpoint_calls(
-    test_client,
-    endpoint,
-    query_params,
-    expected,
+    test_client, endpoint, query_params, expected,
 ):
     url = "/api/" + endpoint
     response = test_client.get(url, query_string=query_params)

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -14,24 +14,27 @@ from ce.tests.helpers.test_utils import check_dict_subset
         (
             "stats",
             {"id_": "", "time": "", "area": "", "variable": ""},
-            None,
+            {},
         ),
         (
             "data",
             {"model": "", "emission": "", "time": "0", "area": "", "variable": ""},
-            None,
+            {},
         ),
         (
             "timeseries",
             {"id_": "", "area": "", "variable": ""},
-            None,
+            {},
         ),
-        ("models", {}, None,),
+        (
+            "models",
+            {},
+            {},
+        ),
         (
             "metadata",
             {
                 "model_id": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
-                "extras": "filepath",
             },
             {
                 "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230": {
@@ -42,8 +45,6 @@ from ce.tests.helpers.test_utils import check_dict_subset
                         "tasmax": "Daily Maximum Temperature"
                     },
                     "ensemble_member": "r1i1p1",
-                    "filepath": re.compile(r"tasmax_mClim_BNU-ESM_historical_r1i1p1_"
-                                           r"19650101-19701230\.nc"),
                     "times": {
                         "0": "1985-01-15T00:00:00Z",
                         "1": "1985-02-15T00:00:00Z",
@@ -62,15 +63,29 @@ from ce.tests.helpers.test_utils import check_dict_subset
                     "multi_year_mean": True,
                     "start_date": "1971-01-01T00:00:00Z",
                     "end_date": "2000-12-31T00:00:00Z"
-                }
+                },
+            },
+        ),
+        (
+            "metadata",
+            {
+                "model_id": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+                "extras": "filepath",
+            },
+            {
+                "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230": {
+                    "institution": "BNU",
+                    "filepath": re.compile(
+                        r"tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230\.nc"
+                    ),
+                },
             },
         ),
         (
             "multimeta",
-            {"ensemble_name": "ce", "model": "", "extras": "filepath"},
+            {"ensemble_name": "ce", "model": ""},
             {
                 "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
-                    "filepath": re.compile(r"CanESM2-rcp85-tasmax-r1i1p1-2010-2039\.nc"),
                     "institution": "CCCMA",
                     "model_id": "CanESM2",
                     "experiment": "rcp85",
@@ -81,16 +96,38 @@ from ce.tests.helpers.test_utils import check_dict_subset
                     "end_date": "2000-12-31T00:00:00Z",
                     "variables": {
                         "tasmax": "Daily Maximum Temperature",
-                    }
+                    },
                 },
             },
         ),
-        ("lister", {"model": ""}, None),
-        ("grid", {"id_": ""}, None),
+        (
+            "multimeta",
+            {"ensemble_name": "ce", "model": "", "extras": "filepath"},
+            {
+                "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
+                    "filepath": re.compile(r"CanESM2-rcp85-tasmax-r1i1p1-2010-2039\.nc"),
+                    "institution": "CCCMA",
+                },
+            },
+        ),
+        (
+            "lister",
+            {"model": ""},
+            {},
+        ),
+        (
+            "grid",
+            {"id_": ""},
+            {},
+        ),
     ],
 )
+@pytest.mark.usefixtures("populateddb")
 def test_api_endpoint_calls(
-    test_client, populateddb, endpoint, query_params, expected,
+    test_client,
+    endpoint,
+    query_params,
+    expected,
 ):
     url = "/api/" + endpoint
     response = test_client.get(url, query_string=query_params)
@@ -99,8 +136,7 @@ def test_api_endpoint_calls(
     assert response.cache_control.max_age > 0
     if endpoint not in ("models", "lister"):
         assert response.last_modified is not None
-    if expected is not None:
-        check_dict_subset(expected, response.get_json())
+    check_dict_subset(expected, response.get_json())
 
 
 def test_dates_are_formatted(test_client, populateddb):

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -5,7 +5,7 @@ import re
 import pytest
 
 from ce.api import find_modtime
-from ce.tests.helpers.test_utils import check_dict_subset
+from test_utils import check_dict_subset
 
 
 @pytest.mark.parametrize(

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -5,28 +5,93 @@ import re
 import pytest
 
 from ce.api import find_modtime
+from ce.tests.helpers.test_utils import check_dict_subset
 
 
 @pytest.mark.parametrize(
-    ("endpoint", "query_params"),
+    "endpoint, query_params, expected",
     [
-        ("stats", {"id_": "", "time": "", "area": "", "variable": ""}),
+        (
+            "stats",
+            {"id_": "", "time": "", "area": "", "variable": ""},
+            None,
+        ),
         (
             "data",
             {"model": "", "emission": "", "time": "0", "area": "", "variable": ""},
+            None,
         ),
-        ("timeseries", {"id_": "", "area": "", "variable": ""}),
-        ("models", {}),
+        (
+            "timeseries",
+            {"id_": "", "area": "", "variable": ""},
+            None,
+        ),
+        ("models", {}, None,),
         (
             "metadata",
-            {"model_id": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"},
+            {
+                "model_id": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+                "extras": "filepath",
+            },
+            {
+                "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230": {
+                    "institution": "BNU",
+                    "model_id": "BNU-ESM",
+                    "experiment": "historical",
+                    "variables": {
+                        "tasmax": "Daily Maximum Temperature"
+                    },
+                    "ensemble_member": "r1i1p1",
+                    "filepath": re.compile(r"tasmax_mClim_BNU-ESM_historical_r1i1p1_"
+                                           r"19650101-19701230\.nc"),
+                    "times": {
+                        "0": "1985-01-15T00:00:00Z",
+                        "1": "1985-02-15T00:00:00Z",
+                        "2": "1985-03-15T00:00:00Z",
+                        "3": "1985-04-15T00:00:00Z",
+                        "4": "1985-05-15T00:00:00Z",
+                        "5": "1985-06-15T00:00:00Z",
+                        "6": "1985-07-15T00:00:00Z",
+                        "7": "1985-08-15T00:00:00Z",
+                        "8": "1985-09-15T00:00:00Z",
+                        "9": "1985-10-15T00:00:00Z",
+                        "10": "1985-11-15T00:00:00Z",
+                        "11": "1985-12-15T00:00:00Z"
+                    },
+                    "timescale": "monthly",
+                    "multi_year_mean": True,
+                    "start_date": "1971-01-01T00:00:00Z",
+                    "end_date": "2000-12-31T00:00:00Z"
+                }
+            },
         ),
-        ("multimeta", {"model": ""}),
-        ("lister", {"model": ""}),
-        ("grid", {"id_": ""}),
+        (
+            "multimeta",
+            {"ensemble_name": "ce", "model": "", "extras": "filepath"},
+            {
+                "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
+                    "filepath": re.compile(r"CanESM2-rcp85-tasmax-r1i1p1-2010-2039\.nc"),
+                    "institution": "CCCMA",
+                    "model_id": "CanESM2",
+                    "experiment": "rcp85",
+                    "ensemble_member": "r1i1p1",
+                    "timescale": "monthly",
+                    "multi_year_mean": True,
+                    "start_date": "1971-01-01T00:00:00Z",
+                    "end_date": "2000-12-31T00:00:00Z",
+                    "variables": {
+                        "tasmax": "Daily Maximum Temperature",
+                    }
+                },
+            },
+        ),
+        ("lister", {"model": ""}, None),
+        ("grid", {"id_": ""}, None),
     ],
 )
-def test_api_endpoints_are_callable(test_client, cleandb, endpoint, query_params):
+def test_api_endpoint_calls(
+    test_client, populateddb, endpoint, query_params, expected,
+):
     url = "/api/" + endpoint
     response = test_client.get(url, query_string=query_params)
     assert response.status_code == 200
@@ -34,6 +99,8 @@ def test_api_endpoints_are_callable(test_client, cleandb, endpoint, query_params
     assert response.cache_control.max_age > 0
     if endpoint not in ("models", "lister"):
         assert response.last_modified is not None
+    if expected is not None:
+        check_dict_subset(expected, response.get_json())
 
 
 def test_dates_are_formatted(test_client, populateddb):

--- a/ce/tests/api/test_metadata.py
+++ b/ce/tests/api/test_metadata.py
@@ -5,20 +5,28 @@ from ce.api import metadata
 
 
 @pytest.mark.parametrize(
-    ("unique_id"),
+    "unique_id",
     (
         "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
         "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
     ),
 )
-def test_metadata(populateddb, unique_id):
+@pytest.mark.parametrize(
+    "extras",
+    (
+        None,
+        "",
+        "filepath",
+        "filepath,obviouslywrong"
+    )
+)
+def test_metadata(populateddb, unique_id, extras):
     sesh = populateddb.session
-    rv = metadata(sesh, unique_id)
+    rv = metadata(sesh, unique_id, extras=extras)
     assert unique_id in rv
     file_metadata = rv[unique_id]
 
     for key in [
-        'filepath',
         "institution",
         "model_id",
         "model_name",
@@ -34,7 +42,8 @@ def test_metadata(populateddb, unique_id):
     ]:
         assert key in file_metadata
 
-    assert f"{unique_id}.nc" in file_metadata["filepath"]
+    if extras is not None and "filepath" in extras:
+        assert f"{unique_id}.nc" in file_metadata["filepath"]
 
     times = file_metadata["times"]
     assert len(times) > 0

--- a/ce/tests/api/test_metadata.py
+++ b/ce/tests/api/test_metadata.py
@@ -18,6 +18,7 @@ def test_metadata(populateddb, unique_id):
     file_metadata = rv[unique_id]
 
     for key in [
+        'filepath',
         "institution",
         "model_id",
         "model_name",
@@ -32,6 +33,8 @@ def test_metadata(populateddb, unique_id):
         "modtime",
     ]:
         assert key in file_metadata
+
+    assert f"{unique_id}.nc" in file_metadata["filepath"]
 
     times = file_metadata["times"]
     assert len(times) > 0

--- a/ce/tests/api/test_metadata.py
+++ b/ce/tests/api/test_metadata.py
@@ -11,15 +11,7 @@ from ce.api import metadata
         "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
     ),
 )
-@pytest.mark.parametrize(
-    "extras",
-    (
-        None,
-        "",
-        "filepath",
-        "filepath,obviouslywrong"
-    )
-)
+@pytest.mark.parametrize("extras", (None, "", "filepath", "filepath,obviouslywrong"))
 def test_metadata(populateddb, unique_id, extras):
     sesh = populateddb.session
     rv = metadata(sesh, unique_id, extras=extras)

--- a/ce/tests/api/test_multimeta.py
+++ b/ce/tests/api/test_multimeta.py
@@ -4,20 +4,40 @@ import pytest
 from ce.api import multimeta
 
 
-@pytest.mark.parametrize(("model"), ("BNU-ESM", ""))
-def test_multimeta(populateddb, model):
-    unique_id = "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"
+@pytest.mark.parametrize("model", (
+    "BNU-ESM",
+    ""
+))
+@pytest.mark.parametrize("unique_id", (
+    "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+    "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"
+))
+def test_multimeta(populateddb, model, unique_id):
     sesh = populateddb.session
-    rv = multimeta(
-        sesh, ensemble_name="ce", model=model
-    )  # Multimeta is wrapped for caching. Call the wrapped function
+    # Multimeta is wrapped for caching. Call the wrapped function
+    rv = multimeta(sesh, ensemble_name="ce", model=model)
     assert unique_id in rv
-    assert rv[unique_id]["model_id"] == "BNU-ESM"
-    # times are not included in the multimeta API call
-    assert "timescale" in rv[unique_id]
-    assert "times" not in rv[unique_id]
-    # make sure start_date and end_date are present
-    assert "start_date" in rv[unique_id]
-    assert "end_date" in rv[unique_id]
-    assert "modtime" in rv[unique_id]
-    assert isinstance(rv[unique_id]["modtime"], datetime)
+    file_metadata = rv[unique_id]
+
+    for key in [
+        "filepath",
+        "institution",
+        "model_id",
+        "model_name",
+        "experiment",
+        "variables",
+        "ensemble_member",
+        "timescale",
+        "multi_year_mean",
+        "start_date",
+        "end_date",
+        "modtime"
+    ]:
+        assert key in file_metadata
+
+    # times are not included in the /multimeta response
+    assert "times" not in file_metadata
+
+    assert f"{unique_id}.nc" in file_metadata["filepath"]
+    assert file_metadata["model_id"] == "BNU-ESM"
+    assert isinstance(file_metadata["modtime"], datetime)

--- a/ce/tests/api/test_multimeta.py
+++ b/ce/tests/api/test_multimeta.py
@@ -6,21 +6,26 @@ from ce.api import multimeta
 
 @pytest.mark.parametrize("model", (
     "BNU-ESM",
-    ""
+    "",
 ))
 @pytest.mark.parametrize("unique_id", (
     "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
-    "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"
+    "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
 ))
-def test_multimeta(populateddb, model, unique_id):
+@pytest.mark.parametrize("extras", (
+    None,
+    "",
+    "filepath",
+    "filepath,obviouslywrong"
+))
+def test_multimeta(populateddb, model, unique_id, extras):
     sesh = populateddb.session
     # Multimeta is wrapped for caching. Call the wrapped function
-    rv = multimeta(sesh, ensemble_name="ce", model=model)
+    rv = multimeta(sesh, ensemble_name="ce", model=model, extras=extras)
     assert unique_id in rv
     file_metadata = rv[unique_id]
 
     for key in [
-        "filepath",
         "institution",
         "model_id",
         "model_name",
@@ -38,6 +43,8 @@ def test_multimeta(populateddb, model, unique_id):
     # times are not included in the /multimeta response
     assert "times" not in file_metadata
 
-    assert f"{unique_id}.nc" in file_metadata["filepath"]
+    if extras is not None and "filepath" in extras:
+        assert f"{unique_id}.nc" in file_metadata["filepath"]
+
     assert file_metadata["model_id"] == "BNU-ESM"
     assert isinstance(file_metadata["modtime"], datetime)

--- a/ce/tests/api/test_multimeta.py
+++ b/ce/tests/api/test_multimeta.py
@@ -4,20 +4,15 @@ import pytest
 from ce.api import multimeta
 
 
-@pytest.mark.parametrize("model", (
-    "BNU-ESM",
-    "",
-))
-@pytest.mark.parametrize("unique_id", (
-    "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
-    "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
-))
-@pytest.mark.parametrize("extras", (
-    None,
-    "",
-    "filepath",
-    "filepath,obviouslywrong"
-))
+@pytest.mark.parametrize("model", ("BNU-ESM", "",))
+@pytest.mark.parametrize(
+    "unique_id",
+    (
+        "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+        "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+    ),
+)
+@pytest.mark.parametrize("extras", (None, "", "filepath", "filepath,obviouslywrong"))
 def test_multimeta(populateddb, model, unique_id, extras):
     sesh = populateddb.session
     # Multimeta is wrapped for caching. Call the wrapped function
@@ -36,7 +31,7 @@ def test_multimeta(populateddb, model, unique_id, extras):
         "multi_year_mean",
         "start_date",
         "end_date",
-        "modtime"
+        "modtime",
     ]:
         assert key in file_metadata
 

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -48,7 +48,7 @@ def dsn(sessiondir,):
 @pytest.fixture
 def app(dsn,):
     app = get_app()
-    app.config['TESTING'] = True
+    app.config["TESTING"] = True
     app.config["SQLALCHEMY_DATABASE_URI"] = dsn
     app.config["SQLALCHEMY_ECHO"] = False
     return app

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -48,6 +48,7 @@ def dsn(sessiondir,):
 @pytest.fixture
 def app(dsn,):
     app = get_app()
+    app.config['TESTING'] = True
     app.config["SQLALCHEMY_DATABASE_URI"] = dsn
     app.config["SQLALCHEMY_ECHO"] = False
     return app
@@ -440,7 +441,8 @@ def populateddb(cleandb,):
 
 @pytest.fixture
 def test_client(app,):
-    return app.test_client()
+    with app.test_client() as client:
+        yield client
 
 
 def db(app,):

--- a/ce/tests/helpers/test_utils.py
+++ b/ce/tests/helpers/test_utils.py
@@ -1,3 +1,4 @@
+import re
 import numpy
 
 
@@ -41,12 +42,20 @@ def check_dict_subset(dict1, dict2, path=[]):
         path_ = path + [key]
         if type(value1) == dict:
             check_dict_subset(value1, value2, path=path_)
+        elif type(value1) == type(re.compile('')) and type(value2) == str:
+            # TODO: Replace `type(re.compile(''))` with `re.Pattern` for Py>=3.7
+            # Special case for comparing strings: if a supplied value is a
+            # regex and the comparison value is a string, then comparison is
+            # regex match.
+            assert value1.search(value2) is not None, \
+                f"Regex '{value1}' does not match string '{value2}'"
         else:
             assert value1 == value2, "{}: {} != {}".format(
                 "".join("['{}']".format(p) for p in path_), value1, value2
             )
 
     for key in dict1.keys():
+        assert key in dict2, f"key '{key}' in dict1 but not in dict2"
         compare(key, dict1[key], dict2[key])
 
 

--- a/ce/tests/helpers/test_utils.py
+++ b/ce/tests/helpers/test_utils.py
@@ -42,13 +42,14 @@ def check_dict_subset(dict1, dict2, path=[]):
         path_ = path + [key]
         if type(value1) == dict:
             check_dict_subset(value1, value2, path=path_)
-        elif type(value1) == type(re.compile('')) and type(value2) == str:
+        elif type(value1) == type(re.compile("")) and type(value2) == str:
             # TODO: Replace `type(re.compile(''))` with `re.Pattern` for Py>=3.7
             # Special case for comparing strings: if a supplied value is a
             # regex and the comparison value is a string, then comparison is
             # regex match.
-            assert value1.search(value2) is not None, \
-                f"Regex '{value1}' does not match string '{value2}'"
+            assert (
+                value1.search(value2) is not None
+            ), f"Regex '{value1}' does not match string '{value2}'"
         else:
             assert value1 == value2, "{}: {} != {}".format(
                 "".join("['{}']".format(p) for p in path_), value1, value2

--- a/doc/source/api/metadata-api-usage.md
+++ b/doc/source/api/metadata-api-usage.md
@@ -1,1 +1,10 @@
-This endpoint returns detailed metadata on a single file. In addition to returning attributes describing the data in the file, it returns a list of all timestamps available within the file. This allows a user to request a map image from the map server corresponding to a specific timestamp.
+This endpoint returns detailed metadata on a single file. 
+In addition to returning attributes describing the data in the file, 
+it returns a list of all timestamps available within the file. 
+This allows a user to request a map image from the map server 
+corresponding to a specific timestamp.
+
+To include the filepath of the file in the response, add the query parameter
+`extras=filepath` to the request. This is used in requests to ncWMS servers 
+configured to provide dynamic datasets. PCIC's ncWMS server is so configured 
+after about 2020 Aug 15.

--- a/doc/source/api/multimeta-api-usage.md
+++ b/doc/source/api/multimeta-api-usage.md
@@ -1,16 +1,42 @@
-This API endpoint provides a list of all the datasets available in a given ensemble. Datasets are identified with a unique identification string. Additional metadata describing the contents of each dataset is provided.
+This API endpoint provides a list of all the datasets available in a given 
+ensemble. Datasets are identified with a unique identification string. 
+Additional metadata describing the contents of each dataset is provided.
 
-This endpoint is intended to provide an overview of all available datasets to enable a caller to decide which datasets are of further interest for numerical data or mapping. It does not return detailed temporal metadata or any spatial metadata; see the `grid` and `metadata` endpoints for more detailed metadata about temporal or spatial extent of a dataset.
+This endpoint is intended to provide an overview of all available datasets 
+to enable a caller to decide which datasets are of further interest for 
+numerical data or mapping. It does not return detailed temporal metadata 
+or any spatial metadata; see the `grid` and `metadata` endpoints for more 
+detailed metadata about temporal or spatial extent of a dataset.
 
 ## Metadata attributes
 * `institution`: The research institution that created this dataset
-* `model_id`: A short abbreviation for the General Circulation Model, Regional Climate Model, or interpolation algorithm that output this dataset
+* `model_id`: A short abbreviation for the General Circulation Model, Regional 
+Climate Model, or interpolation algorithm that output this dataset
 * `model_name`: The full name of the model that created this dataset
-* `experiment`: The emissions scenario used to model this data. Emissions scenarios represent a range of possible future projections for greenhouse gas concentration in the atmosphere, typically one of the Representative Concentration Pathways (RCP). May be "historical" for datasets based on historical data
-* `variables`: A list of variables in this dataset, with name and a short description. Variables are the numerical quantities being measured or projected, such as maximum temperature, precipitation, or derived indices.
-* `ensemble_member`: A model may be run multiple times with different initialization conditions; data from these runs is distinguished by the ensemble_member attribute
-* `timescale`: The temporal resolution of the data. `monthly`, `seasonal`, or `yearly`
-* `multi_year_mean`: Whether or not this datafile is a climatological aggregate. In a climatological aggregate dataset, the value at each timestamp represents a combination of values at that timestamp across multiple years. For example, a 1961-1990 climatological mean would have one value for January that represented the mean value of January 1961, January 1962, etc. 
+* `experiment`: The emissions scenario used to model this data. 
+Emissions scenarios represent a range of possible future projections for 
+greenhouse gas concentration in the atmosphere, typically one of the 
+Representative Concentration Pathways (RCP). May be "historical" for 
+datasets based on historical data
+* `variables`: A list of variables in this dataset, with name and a short 
+description. Variables are the numerical quantities being measured or 
+projected, such as maximum temperature, precipitation, or derived indices.
+* `ensemble_member`: A model may be run multiple times with different 
+initialization conditions; data from these runs is distinguished by the 
+ensemble_member attribute
+* `timescale`: The temporal resolution of the data. `monthly`, `seasonal`, 
+or `yearly`
+* `multi_year_mean`: Whether or not this datafile is a climatological 
+aggregate. In a climatological aggregate dataset, the value at each timestamp 
+represents a combination of values at that timestamp across multiple years. 
+For example, a 1961-1990 climatological mean would have one value for January 
+that represented the mean value of January 1961, January 1962, etc. 
 * `start_date`: The start of the temporal interval described by this dataset 
 * `end_date`: The end of the temporal interval described by this dataset
-* `modtime`: The most recent data this dataset was updated. Useful for determining whether to cache data.
+* `modtime`: The most recent data this dataset was updated. Useful for 
+determining whether to cache data.
+* `filepath`: (optional) The filepath of the data file in the local storage
+ system. This is used in requests to ncWMS servers configured to provide
+ dynamic datasets. PCIC's ncWMS server is so configured after about 2020 Aug 15.
+To include the filepath of the file in the response, add the query parameter
+`extras=filepath` to the request.

--- a/doc/source/workflow.md
+++ b/doc/source/workflow.md
@@ -2,43 +2,151 @@
 
 ## List Available Datasets
 
-Datafiles are organized into ensembles containing all data needed for a specific purpose. (The term "ensemble" is a misnomer in this usage; a more appropriate term would be "collection." For historical reasons the term "ensemble" is embedded in the code and it is not easily changed at this point.)
+Datafiles are organized into ensembles containing all data needed for a 
+specific purpose. (The term "ensemble" is a misnomer in this usage; a more 
+appropriate term would be "collection." For historical reasons the term 
+"ensemble" is embedded in the code and it is not easily changed at this point.)
 
-To view a list of all datasets in a particular ensemble, query the `multimeta` API. The `multimeta` API gives each datafile as a unique identifier string and a collection of attributes describing the data contained within that file. After a datafile of interest has been determined from its metadata attributes, its unique identifier string may be used to request the data.
+To view a list of all datasets in a particular ensemble, query the 
+`multimeta` API. The `multimeta` API gives each datafile as a unique identifier 
+string and a collection of attributes describing the data contained within that 
+file. After a datafile of interest has been determined from its metadata 
+attributes, its unique identifier string may be used to request the data.
 
-The `multi_year_mean` attribute is an important attribute of datafiles. Datafiles with `multi_year_mean` equal to `true` represent climatological aggregates. Each individual value in these files represents a mean or stanard deviation calculated across multiple years, typically thirty years, which is standard in climate science. For example, a monthly climatological mean might cover 1961-1990, but feature only twelve timestamps. The January timestamp is the mean of the value for January 1961, January 1962, and so on up to January 1990. The February timestamp is the mean of the values for February 1961, February 1962, and so on. Climatological means may be monthly, seasonal, or annual. This API primarily supports analysis of climatological datasets, and more analysis options are available for them.
+The `multi_year_mean` attribute is an important attribute of datafiles. 
+Datafiles with `multi_year_mean` equal to `true` represent climatological 
+aggregates. Each individual value in these files represents a mean or stanard 
+deviation calculated across multiple years, typically thirty years, which is 
+standard in climate science. For example, a monthly climatological mean might 
+cover 1961-1990, but feature only twelve timestamps. The January timestamp is 
+the mean of the value for January 1961, January 1962, and so on up to January 
+1990. The February timestamp is the mean of the values for February 1961, 
+February 1962, and so on. Climatological means may be monthly, seasonal, 
+or annual. This API primarily supports analysis of climatological datasets, 
+and more analysis options are available for them.
 
-Datasets with `multi_year_mean` equal to `false` represent nominal time datasets; no aggregation has been done between years. A monthly dataset covering 1961-1990 would feature 360 timestamps.
+Datasets with `multi_year_mean` equal to `false` represent nominal time 
+datasets; no aggregation has been done between years. A monthly dataset 
+covering 1961-1990 would feature 360 timestamps.
 
 ## Request Numerical Data From A Climatological Aggregate Datafile
 
-The `timeseries` endpoint returns a timeseries with the mean value for each timestamp in the datafile. It requires a datafile's unique identification string, and optionally a spatial area of interest defined as a Well Known Text (WKT) Polygon or Point. For a climatological aggregate datafile, the resulting timeseries represents an average annual cycle over the period described by the dataset. The annual cycle may have twelve monthly values, four seasonal values, or a single annual value.
+The `timeseries` endpoint returns a timeseries with the mean value for each 
+timestamp in the datafile. It requires a datafile's unique identification 
+string, and optionally a spatial area of interest defined as a Well Known 
+Text (WKT) Polygon or Point. For a climatological aggregate datafile, the 
+resulting timeseries represents an average annual cycle over the period 
+described by the dataset. The annual cycle may have twelve monthly values, 
+four seasonal values, or a single annual value.
 
-The `stats` endpoint returns statistical measures (`mean`, `stdev`, `min`, `max`, and `median`) of a single dataset identified by its unique identification string. The timestep of interest is defined by a temporal index. An optional spatial area of interest may be defined as a WKT Polygon or Point. The statistical measures will be calculated over the time and space extent within the dataset.
+The `stats` endpoint returns statistical measures (`mean`, `stdev`, `min`, 
+`max`, and `median`) of a single dataset identified by its unique 
+identification string. The timestep of interest is defined by a temporal index. 
+An optional spatial area of interest may be defined as a WKT Polygon or Point. 
+The statistical measures will be calculated over the time and space extent 
+within the dataset.
 
-You may wish to compare the statistical measures of a related set of climatological aggregate datafiles. The `multistats` query functions similarly to the `stats` query, but on several files that share common parameters at once. The `multistats` query may be called with parameters that describe a set of datasets by specifying all parameters except the start and end dates, as well as a time index and optional spatial area of interest. It responds with the same information as the `stats` query, but for every datafile that matches the parameters.
+You may wish to compare the statistical measures of a related set of 
+climatological aggregate datafiles. The `multistats` query functions 
+similarly to the `stats` query, but on several files that share common 
+parameters at once. The `multistats` query may be called with parameters 
+that describe a set of datasets by specifying all parameters except the start 
+and end dates, as well as a time index and optional spatial area of interest. 
+It responds with the same information as the `stats` query, but for every 
+datafile that matches the parameters.
 
-Similarly, the `data` API is also queried by submitting parameters that describe a set of datafiles by specifying all parameters except the start and end dates, as well as a time index and optional spatial area of interest. It returns a timeseries constructed from all climatological aggregate files that meet the parameters. For example, it would return the January value for the 1961-1990 climatology, the January value for the 1971-2000 climatology, etc, to make a timeseries showing projected long-term change over time of the mean value for January.
+Similarly, the `data` API is also queried by submitting parameters that 
+describe a set of datafiles by specifying all parameters except the start 
+and end dates, as well as a time index and optional spatial area of interest. 
+It returns a timeseries constructed from all climatological aggregate files 
+that meet the parameters. For example, it would return the January value for 
+the 1961-1990 climatology, the January value for the 1971-2000 climatology, 
+etc, to make a timeseries showing projected long-term change over time of the 
+mean value for January.
 
 ### Request Streamflow Data From A Climatological Aggregate Datafile
 
-The typical use case for streamflow data is to determine flow at a single point corresponding to a location on a river or stream. Average streamflow over an area is not useful in most cases. The `timeseries`, `data` and `multistats` API endpoints accept WKT Points for the `area` parameter and may be used to request annual timeseries, long term data, or summary statistics for streamflow at a given point, similar to any other climatological aggregate dataset. 
+The typical use case for streamflow data is to determine flow at a single 
+point corresponding to a location on a river or stream. Average streamflow 
+over an area is not useful in most cases. The `timeseries`, `data` and 
+`multistats` API endpoints accept WKT Points for the `area` parameter and 
+may be used to request annual timeseries, long term data, or summary statistics 
+for streamflow at a given point, similar to any other climatological aggregate 
+dataset. 
 
-While this is subject to change, all streamflow data are available in the ensemble named `bc_moti`, with variable name equal to `streamflow`.
+While this is subject to change, all streamflow data are available in the 
+ensemble named `bc_moti`, with variable name equal to `streamflow`.
 
-When requesting streamflow data from a point, please be cautious and aware of potential differences in precision. Note that while you may supply a point with arbitrarily precise longitude and latitude values to the API, the streamflow data is a gridded dataset and has only one value available per grid cell. If you supply the coordinates of a small creek inside the same grid cell as a river, the data you receive is for the total flow through that grid cell; it is primarily influenced by the river. Accordingly, this dataset is more accurate for larger streams, and should not be considered accurate for streams that drain watersheds of less than 200 kilometers area. Information on the grid corresponding to a dataset can be obtained from the `grid` API, which will provide a list of the longitudes and latitudes corresponding to the centroids of each grid cell.
+When requesting streamflow data from a point, please be cautious and aware 
+of potential differences in precision. Note that while you may supply a point
+ with arbitrarily precise longitude and latitude values to the API, the 
+ streamflow data is a gridded dataset and has only one value available per 
+ grid cell. If you supply the coordinates of a small creek inside the same 
+ grid cell as a river, the data you receive is for the total flow through 
+ that grid cell; it is primarily influenced by the river. Accordingly, 
+ this dataset is more accurate for larger streams, and should not be 
+ considered accurate for streams that drain watersheds of less than 200 
+ kilometers area. Information on the grid corresponding to a dataset can 
+ be obtained from the `grid` API, which will provide a list of the longitudes 
+ and latitudes corresponding to the centroids of each grid cell.
 
-To get contextual information on the watershed that drains to the streamflow location of interest, the `watershed` API can be invoked with the same WKT Point used to request streamflow data. This API provides information on the topology and extent of the watershed that drains to the grid cell containing the specified point. The outline of the watershed is provided as a GeoJSON object. This outline, like the streamflow data itself, has a resolution determined by the size of a grid cell.
+To get contextual information on the watershed that drains to the streamflow 
+location of interest, the `watershed` API can be invoked with the same 
+WKT Point used to request streamflow data. This API provides information on 
+the topology and extent of the watershed that drains to the grid cell 
+containing the specified point. The outline of the watershed is provided as a 
+GeoJSON object. This outline, like the streamflow data itself, has a 
+resolution determined by the size of a grid cell.
 
-The GeoJSON watershed polygon can furthermore be used to request data on processes across the entire watershed that drains to a point, such as average precipitation across the watershed. If the polygon is converted to WKT format, it can be passed as the `area` argument to the `timeseries`, `data`, or `multistats` API endpoints to request climate data across the watershed for the same time period and model.
+The GeoJSON watershed polygon can furthermore be used to request data on 
+processes across the entire watershed that drains to a point, such as 
+average precipitation across the watershed. If the polygon is converted to 
+WKT format, it can be passed as the `area` argument to the `timeseries`, 
+`data`, or `multistats` API endpoints to request climate data across the 
+watershed for the same time period and model.
 
 
 ## Request A Non-Climatological Timeseries
 
-Fewer options are available for datafiles with the `multi_year_mean` attribute of `false`, which have no guarenteed temporal structure or organization. The `timeseries` API endpoint requires a datafile's unique identification string and optionally a spatial area of interest. It responds with a timeseries consisting of the average values over the area of interest, one for each timestamp in the datafile. The timestamps need not be evenly spaced.
+Fewer options are available for datafiles with the `multi_year_mean` 
+attribute of `false`, which have no guarenteed temporal structure or 
+organization. The `timeseries` API endpoint requires a datafile's unique 
+identification string and optionally a spatial area of interest. It responds 
+with a timeseries consisting of the average values over the area of interest, 
+one for each timestamp in the datafile. The timestamps need not be evenly 
+spaced.
 
 ## Request a Map 
 
-In order to request a data map image from PCIC's ncWMS server, two piece of information are requred. Firstly, the identification string of the file is required. The identification string of the file of interest can be determined from the `multimeta` query, which lists all files available in a collection.
+In order to request a data map image from PCIC's ncWMS server, two pieces of 
+information are required, the dataset identifier and the timestamp.
 
-A timestamp is also needed for ncWMS. The `metadata` API endpoint can be accessed with the datafile's unique identification string, and provides a list of timestamps available in the file, which would be usable by ncWMS.
+### Dataset identifier
+
+The PCIC ncWMS server has been configured to use two different methods of 
+identifying a dataset:
+
+- By unique id (before approximately Aug 15, 2020): 
+  `layers=<unique_id>/<variable>`
+- By filepath (after)
+  `layers=<prefix>/<filepath>/<variable>`
+
+
+Both `unique_id` and `filepath` are obtained from the 
+`/multimeta` or `/metadata` query, which provide metadata for, respectively, 
+all datasets in a collection or a single specific dataset. 
+
+Attribute `unique_id` is included in all responses, as the top-level key to 
+the dictionary of values returned.
+
+To include `filepath` in the response, the metadata query should include
+the query parameter `extras=filepath`.
+For example, `/multimeta?...&extras=filepath`. Each item in the dictionary
+then includes a `filepath` attribute. 
+This feature is only available in Climate Explorer backend since release 3.0.1.
+
+### Timestamp
+
+A timestamp is also needed for ncWMS. The `/metadata` API endpoint can be 
+accessed with the datafile's unique identification string, and provides a 
+list of timestamps available in the file, which would be usable by ncWMS.


### PR DESCRIPTION
Resolves #149 

This PR adds an `extras` param to ` /metadata` and `/multimeta`, which can take a comma-separated list of extra properties to provide for each file it returns. Currently, the single valid value is  `filepath`, which adds a `filepath` property containing ... wait for it ... the file's filepath.

There are also some improvements in tests, and some blackening of code. The bulk of changes is data for tests.