### PR TITLE
Thredds data

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,10 +20,10 @@ jobs:
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
       run: |
-        py.test -v --tb=short
+        py.test -m "not online" -v --tb=short
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |
-        py.test -m "not slow" -v --tb=short
+        py.test -m "not online and not slow" -v --tb=short
     - name: Code format check
       run: black . --check

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ apt:
 	sudo apt-get install -y \
 		libpq-dev \
 		python3-dev \
+		python3-distutils \
 		libhdf5-dev \
 		libnetcdf-dev \
 		libgdal-dev

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -49,6 +49,10 @@ def data(
 
         ensemble_name (str): Name of ensemble
 
+        is_thredds (bool): If set to `True` the filepath will be searched for
+            on THREDDS server. This flag is not needed when running the backend
+            as a server as the files are accessed over the web.
+
     Returns:
         dict:
             Empty dictionary if there exist no files matching the provided
@@ -112,6 +116,7 @@ def data(
 
         :param data_file (modelmeta.DataFile): source data file
         :param time_idx (int): index of time of interest
+        :param is_thredds (bool): whether data target is on thredds server
         :return: float
         """
         if isinstance(is_thredds, str):

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -7,6 +7,7 @@ import os
 from modelmeta import Run, Emission, Model, TimeSet, DataFile
 from modelmeta import DataFileVariableGridded, Ensemble
 from ce.api.util import get_array, get_units_from_run_object, open_nc
+from distutils.util import strtobool
 
 
 def data(

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -2,6 +2,7 @@
 """
 
 import numpy as np
+import os
 
 from modelmeta import Run, Emission, Model, TimeSet, DataFile
 from modelmeta import DataFileVariableGridded, Ensemble
@@ -112,6 +113,8 @@ def data(
         :param time_idx (int): index of time of interest
         :return: float
         """
+        if "/storage" in data_file.filename:
+            data_file.filename = os.getenv("THREDDS_URL_ROOT") + data_file.filename
         with open_nc(data_file.filename) as nc:
             a = get_array(nc, data_file.filename, time_idx, area, variable)
         return np.mean(a).item()

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -124,10 +124,12 @@ def data(
             is_thredds = strtobool(is_thredds)
 
         if is_thredds:
-            data_file.filename = os.getenv("THREDDS_URL_ROOT") + data_file.filename
+            data_filename = os.getenv("THREDDS_URL_ROOT") + data_file.filename
+        else:
+            data_filename = data_file.filename
 
-        with open_nc(data_file.filename) as nc:
-            a = get_array(nc, data_file.filename, time_idx, area, variable)
+        with open_nc(data_filename) as nc:
+            a = get_array(nc, data_filename, time_idx, area, variable)
         return np.mean(a).item()
 
     def get_time_value(timeset, time_idx):

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -10,6 +10,7 @@ from shapely.affinity import translate
 from shapely.geometry import mapping  # convert a Shapely Geom to GeoJSON
 import rasterio
 from rasterio.mask import raster_geometry_mask as rio_getmask
+import os
 
 # From http://stackoverflow.com/a/30316760/597593
 from numbers import Number
@@ -283,3 +284,4 @@ def rasterio_thredds_helper(fname):
         yield temp.name
     finally:
         temp.close()
+        os.remove(temp.name)

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -3,6 +3,8 @@ import sys
 from collections import OrderedDict
 from threading import RLock
 from contextlib import ContextDecorator, contextmanager
+import shutil
+import requests
 
 import numpy as np
 from shapely.wkt import loads, dumps
@@ -17,7 +19,6 @@ from numbers import Number
 from collections import Set, Mapping, deque
 
 from tempfile import NamedTemporaryFile
-from urllib.request import urlopen
 
 
 try:  # Python 2
@@ -276,11 +277,8 @@ def rasterio_thredds_helper(resource):
 
     try:
         temp = NamedTemporaryFile(mode="wb", suffix=".nc", delete=False)
-        with urlopen(resource_name) as resp:
-            chunk = resp.read(2 ** 16)
-            while chunk:
-                temp.write(chunk)
-                chunk = resp.read(2 ** 16)
+        with requests.get(resource_name, stream=True) as file_source:
+            shutil.copyfileobj(file_source.raw, temp)
         yield temp.name
     finally:
         temp.close()

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -15,8 +15,7 @@ def multistats(
     variable="",
     timescale="",
     cell_method="mean",
-    thredds=False,
-    thredds_root="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
+    is_thredds=False,
 ):
     """Request and calculate statistics for multiple models or scenarios
 
@@ -55,12 +54,8 @@ def multistats(
             climatological dataset (e.g "mean" or "standard_deviation").
             Defaulted to "mean".
 
-        thredds (bool): If set to `True` the filepath will be searched for
+        is_thredds (bool): If set to `True` the filepath will be searched for
             on THREDDS server.
-
-        thredds_root (str): The portion of the thredds url that will be constant
-            for all filepaths.
-
 
     Returns:
         dict: Empty dictionary if no unique_ids matched the search.
@@ -102,7 +97,4 @@ def multistats(
     ids = search_for_unique_ids(
         sesh, ensemble_name, model, emission, variable, time, timescale, cell_method
     )
-    return {
-        id_: stats(sesh, id_, time, area, variable, thredds, thredds_root)[id_]
-        for id_ in ids
-    }
+    return {id_: stats(sesh, id_, time, area, variable, is_thredds)[id_] for id_ in ids}

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -55,7 +55,8 @@ def multistats(
             Defaulted to "mean".
 
         is_thredds (bool): If set to `True` the filepath will be searched for
-            on THREDDS server.
+            on THREDDS server. This flag is not needed when running the backend
+            as a server as the files are accessed over the web.
 
     Returns:
         dict: Empty dictionary if no unique_ids matched the search.

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -15,6 +15,7 @@ def multistats(
     variable="",
     timescale="",
     cell_method="mean",
+    thredds=False,
 ):
     """Request and calculate statistics for multiple models or scenarios
 
@@ -52,6 +53,9 @@ def multistats(
         cell_method (str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean" or "standard_deviation").
             Defaulted to "mean".
+
+        thredds (bool): If set to `True` the filepath will be searched for
+            on THREDDS server
 
     Returns:
         dict: Empty dictionary if no unique_ids matched the search.
@@ -93,4 +97,4 @@ def multistats(
     ids = search_for_unique_ids(
         sesh, ensemble_name, model, emission, variable, time, timescale, cell_method
     )
-    return {id_: stats(sesh, id_, time, area, variable)[id_] for id_ in ids}
+    return {id_: stats(sesh, id_, time, area, variable, thredds)[id_] for id_ in ids}

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -16,6 +16,7 @@ def multistats(
     timescale="",
     cell_method="mean",
     thredds=False,
+    thredds_root="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
 ):
     """Request and calculate statistics for multiple models or scenarios
 
@@ -55,7 +56,11 @@ def multistats(
             Defaulted to "mean".
 
         thredds (bool): If set to `True` the filepath will be searched for
-            on THREDDS server
+            on THREDDS server.
+
+        thredds_root (str): The portion of the thredds url that will be constant
+            for all filepaths.
+
 
     Returns:
         dict: Empty dictionary if no unique_ids matched the search.
@@ -97,4 +102,7 @@ def multistats(
     ids = search_for_unique_ids(
         sesh, ensemble_name, model, emission, variable, time, timescale, cell_method
     )
-    return {id_: stats(sesh, id_, time, area, variable, thredds)[id_] for id_ in ids}
+    return {
+        id_: stats(sesh, id_, time, area, variable, thredds, thredds_root)[id_]
+        for id_ in ids
+    }

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -50,8 +50,9 @@ def stats(
 
         variable (str): Short name of the variable to be returned
 
-        thredds (bool): If set to `True` the filepath will be searched for
-            on THREDDS server.
+        is_thredds (bool): If set to `True` the filepath will be searched for
+            on THREDDS server. This flag is not needed when running the backend
+            as a server as the files are accessed over the web.
 
     Returns:
         dict: Empty dictionary if model_id is not found in the database.

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -24,7 +24,15 @@ na_array_stats = {
 }
 
 
-def stats(sesh, id_, time, area, variable, thredds=False):
+def stats(
+    sesh,
+    id_,
+    time,
+    area,
+    variable,
+    thredds=False,
+    thredds_root="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
+):
     """Request and calculate summary statistics averaged across a region
 
     For performing regional analysis, one typically wants to summarize
@@ -46,6 +54,12 @@ def stats(sesh, id_, time, area, variable, thredds=False):
         area (str): WKT polygon of selected area
 
         variable (str): Short name of the variable to be returned
+
+        thredds_root (str): The portion of the thredds url that will be constant
+            for all filepaths.
+
+        thredds (bool): If set to `True` the filepath will be searched for
+            on THREDDS server.
 
     Returns:
         dict: Empty dictionary if model_id is not found in the database.
@@ -97,7 +111,11 @@ def stats(sesh, id_, time, area, variable, thredds=False):
 
     try:
         df = sesh.query(DataFile).filter(DataFile.unique_id == id_).one()
-        fname = df.filename if not thredds else apply_thredds_root(df.filename)
+        fname = (
+            df.filename
+            if not thredds
+            else apply_thredds_root(thredds_root, df.filename)
+        )
     except NoResultFound:
         return {}
 

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -111,7 +111,7 @@ def stats(
 
     try:
         df = sesh.query(DataFile).filter(DataFile.unique_id == id_).one()
-        fname = (
+        resource = (
             df.filename
             if not thredds
             else apply_thredds_root(thredds_root, df.filename)
@@ -120,8 +120,8 @@ def stats(
         return {}
 
     try:
-        with open_nc(fname) as nc:
-            array = get_array(nc, fname, time, area, variable)
+        with open_nc(resource) as nc:
+            array = get_array(nc, resource, time, area, variable)
             units = get_units_from_netcdf_file(nc, variable)
     except Exception as e:
         log.error(e)

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -25,13 +25,7 @@ na_array_stats = {
 
 
 def stats(
-    sesh,
-    id_,
-    time,
-    area,
-    variable,
-    thredds=False,
-    thredds_root="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
+    sesh, id_, time, area, variable, is_thredds=False,
 ):
     """Request and calculate summary statistics averaged across a region
 
@@ -54,9 +48,6 @@ def stats(
         area (str): WKT polygon of selected area
 
         variable (str): Short name of the variable to be returned
-
-        thredds_root (str): The portion of the thredds url that will be constant
-            for all filepaths.
 
         thredds (bool): If set to `True` the filepath will be searched for
             on THREDDS server.
@@ -111,11 +102,7 @@ def stats(
 
     try:
         df = sesh.query(DataFile).filter(DataFile.unique_id == id_).one()
-        resource = (
-            df.filename
-            if not thredds
-            else apply_thredds_root(thredds_root, df.filename)
-        )
+        resource = df.filename if not is_thredds else apply_thredds_root(df.filename)
     except NoResultFound:
         return {}
 

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.ma as ma
 from sqlalchemy.orm.exc import NoResultFound
 import logging
+from distutils.util import strtobool
 
 from modelmeta import DataFile, Time
 
@@ -99,6 +100,9 @@ def stats(
             )
     else:
         time = None
+
+    if isinstance(is_thredds, str):
+        is_thredds = strtobool(is_thredds)
 
     try:
         df = sesh.query(DataFile).filter(DataFile.unique_id == id_).one()

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -8,7 +8,13 @@ import logging
 
 from modelmeta import DataFile, Time
 
-from ce.api.util import get_array, get_units_from_netcdf_file, mean_datetime, open_nc
+from ce.api.util import (
+    get_array,
+    get_units_from_netcdf_file,
+    mean_datetime,
+    open_nc,
+    apply_thredds_root,
+)
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +24,7 @@ na_array_stats = {
 }
 
 
-def stats(sesh, id_, time, area, variable):
+def stats(sesh, id_, time, area, variable, thredds=False):
     """Request and calculate summary statistics averaged across a region
 
     For performing regional analysis, one typically wants to summarize
@@ -91,7 +97,7 @@ def stats(sesh, id_, time, area, variable):
 
     try:
         df = sesh.query(DataFile).filter(DataFile.unique_id == id_).one()
-        fname = df.filename
+        fname = df.filename if not thredds else apply_thredds_root(df.filename)
     except NoResultFound:
         return {}
 

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -229,10 +229,7 @@ def neighbours(cell):
     return (vec_add(cell, offset) for offset in neighbour_offsets)
 
 
-def apply_thredds_root(
-    filename,
-    root="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
-):
+def apply_thredds_root(root, filename):
     """Apply thredds root to filename
 
     PCIC's THREDDS data server stores files that follow the same filepath

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -54,33 +54,33 @@ def get_grid_from_netcdf_file(nc):
 
 
 @contextmanager
-def open_nc(fname):
-    if not "http" in fname and not os.path.exists(fname):
+def open_nc(resource):
+    if not "http" in resource and not os.path.exists(resource):
         raise Exception(
-            f"File name: {fname} is not valid, database not in sync with filesystem."
+            f"The metadata database is out of sync with the filesystem. I was told to open file with name {resource}, but it does not exist."
         )
 
     try:
-        nc = Dataset(fname, "r")
+        nc = Dataset(resource, "r")
         nc.set_always_mask(False)
         yield nc
     finally:
         nc.close()
 
 
-def get_array(nc, fname, time, area, variable):
+def get_array(nc, resource, time, area, variable):
 
     if variable not in nc.variables:
-        raise Exception("File {} does not have variable {}.".format(fname, variable))
+        raise Exception(f"Resource {resource} does not have variable {variable}.")
 
     a = nc.variables[variable]
 
     if area:
         # Mask out data that isn't inside the input polygon
-        a = wkt_to_masked_array(nc, fname, area, variable)
-        a = time_slice_array(a, time, nc, fname, variable)
+        a = wkt_to_masked_array(nc, resource, area, variable)
+        a = time_slice_array(a, time, nc, resource, variable)
     else:
-        a = time_slice_array(a, time, nc, fname, variable)
+        a = time_slice_array(a, time, nc, resource, variable)
         a = ma.masked_array(a)
 
     return a
@@ -90,10 +90,10 @@ def get_array(nc, fname, time, area, variable):
 # Reduces a 3-dimensional array to a two-dimensional array by
 # returning the timeidxth slice, IFF time is defined and time
 # is a dimension in the netCDF. Otherwise return array unchanged.
-def time_slice_array(a, timeidx, nc, fname, variable):
+def time_slice_array(a, timeidx, nc, resource, variable):
     if timeidx or timeidx == 0:
         if "time" not in nc.variables[variable].dimensions:
-            raise Exception("File {} does not have a time dimension".format(fname))
+            raise Exception(f"Resource {resource} does not have a time dimension")
         a = a[timeidx, :, :]
     return a
 

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -55,10 +55,9 @@ def get_grid_from_netcdf_file(nc):
 
 @contextmanager
 def open_nc(fname):
-    if not os.path.exists(fname):
+    if not "http" in fname and not os.path.exists(fname):
         raise Exception(
-            "The metadata database is out of sync with the filesystem. "
-            "I was told to open the file {}, but it does not exist.".format(fname)
+            f"File name: {fname} is not valid, database not in sync with filesystem."
         )
 
     try:
@@ -228,3 +227,16 @@ def neighbours(cell):
     """Return all neighbours of `cell`: all cells with an x or y offset
     of +/-1"""
     return (vec_add(cell, offset) for offset in neighbour_offsets)
+
+
+def apply_thredds_root(
+    filename,
+    root="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
+):
+    """Apply thredds root to filename
+
+    PCIC's THREDDS data server stores files that follow the same filepath
+    pattern found in `/storage`. To access it, we just want to add on the first
+    section of the url, the rest will be the same.
+    """
+    return root + filename

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -229,11 +229,17 @@ def neighbours(cell):
     return (vec_add(cell, offset) for offset in neighbour_offsets)
 
 
-def apply_thredds_root(root, filename):
+def apply_thredds_root(filename):
     """Apply thredds root to filename
 
     PCIC's THREDDS data server stores files that follow the same filepath
     pattern found in `/storage`. To access it, we just want to add on the first
     section of the url, the rest will be the same.
     """
-    return root + filename
+    thredds_url_root = os.getenv("THREDDS_URL_ROOT")
+    if not thredds_url_root:
+        raise Exception(
+            "You must set the THREDDS_URL_ROOT environment variable to use the server"
+        )
+
+    return thredds_url_root + filename

--- a/ce/tests/api/test_data.py
+++ b/ce/tests/api/test_data.py
@@ -21,6 +21,7 @@ def test_data_bad_time(populateddb):
     )
 
 
+@pytest.mark.online
 @pytest.mark.parametrize("variable", ("tasmax", "tasmin",))
 @pytest.mark.parametrize(
     "timescale, time_idx, expected_ymd",

--- a/ce/tests/api/test_data.py
+++ b/ce/tests/api/test_data.py
@@ -31,7 +31,9 @@ def test_data_bad_time(populateddb):
         ("yearly", 0, (1985, 7, 2)),
     ),
 )
-def test_data_single_file(populateddb, variable, timescale, time_idx, expected_ymd):
+def test_data_single_file(
+    populateddb, mock_thredds_url_root, variable, timescale, time_idx, expected_ymd
+):
     rv = data(
         populateddb.session,
         model="BNU-ESM",

--- a/ce/tests/api/test_stats.py
+++ b/ce/tests/api/test_stats.py
@@ -5,6 +5,7 @@ import pytest
 from ce.api import stats
 
 
+@pytest.mark.online
 @pytest.mark.parametrize(
     "unique_id, var_name, thredds",
     [

--- a/ce/tests/api/test_stats.py
+++ b/ce/tests/api/test_stats.py
@@ -13,12 +13,12 @@ from ce.api import stats
         ("tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax", False),
         ("tasmax_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax", False),
         ("tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
-        ("tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
-        ("tasmin_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
+        ("tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", "false"),
+        ("tasmin_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", "false"),
         (
             "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
             "tasmax",
-            True,
+            "true",
         ),
         (
             "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",

--- a/ce/tests/api/test_stats.py
+++ b/ce/tests/api/test_stats.py
@@ -7,7 +7,7 @@ from ce.api import stats
 
 @pytest.mark.online
 @pytest.mark.parametrize(
-    "unique_id, var_name, thredds",
+    "unique_id, var_name, is_thredds",
     [
         ("tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax", False),
         ("tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax", False),
@@ -27,9 +27,11 @@ from ce.api import stats
         ),
     ],
 )
-def test_stats(populateddb, polygon, unique_id, var_name, thredds):
+def test_stats(
+    populateddb, polygon, mock_thredds_url_root, unique_id, var_name, is_thredds
+):
     sesh = populateddb.session
-    rv = stats(sesh, unique_id, None, polygon, var_name, thredds)
+    rv = stats(sesh, unique_id, None, polygon, var_name, is_thredds)
     statistics = rv[unique_id]
     for attr in ("min", "max", "mean", "median", "stdev"):
         value = statistics[attr]

--- a/ce/tests/api/test_stats.py
+++ b/ce/tests/api/test_stats.py
@@ -16,12 +16,12 @@ from ce.api import stats
         ("tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
         ("tasmin_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
         (
-            "/storage/data/projects/comp_support/daccs/test-data/tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+            "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
             "tasmax",
             True,
         ),
         (
-            "/storage/data/projects/comp_support/daccs/test-data/tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+            "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
             "tasmin",
             True,
         ),

--- a/ce/tests/api/test_stats.py
+++ b/ce/tests/api/test_stats.py
@@ -6,19 +6,29 @@ from ce.api import stats
 
 
 @pytest.mark.parametrize(
-    "unique_id, var_name",
+    "unique_id, var_name, thredds",
     [
-        ("tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax"),
-        ("tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax"),
-        ("tasmax_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax"),
-        ("tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin"),
-        ("tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin"),
-        ("tasmin_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin"),
+        ("tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax", False),
+        ("tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax", False),
+        ("tasmax_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmax", False),
+        ("tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
+        ("tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
+        ("tasmin_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230", "tasmin", False),
+        (
+            "/storage/data/projects/comp_support/daccs/test-data/tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+            "tasmax",
+            True,
+        ),
+        (
+            "/storage/data/projects/comp_support/daccs/test-data/tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+            "tasmin",
+            True,
+        ),
     ],
 )
-def test_stats(populateddb, polygon, unique_id, var_name):
+def test_stats(populateddb, polygon, unique_id, var_name, thredds):
     sesh = populateddb.session
-    rv = stats(sesh, unique_id, None, polygon, var_name)
+    rv = stats(sesh, unique_id, None, polygon, var_name, thredds)
     statistics = rv[unique_id]
     for attr in ("min", "max", "mean", "median", "stdev"):
         value = statistics[attr]

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -195,6 +195,10 @@ def populateddb(cleandb,):
     df_5_monthly = make_data_file(
         unique_id="tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", run=run3,
     )
+    df_5_monthly_online = make_data_file(
+        unique_id="/storage/data/projects/comp_support/daccs/test-data/tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+        run=run3,
+    )
     df_5_seasonal = make_data_file(
         unique_id="tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", run=run3,
     )
@@ -203,6 +207,10 @@ def populateddb(cleandb,):
     )
     df_6_monthly = make_data_file(
         unique_id="tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", run=run3,
+    )
+    df_6_monthly_online = make_data_file(
+        unique_id="/storage/data/projects/comp_support/daccs/test-data/tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+        run=run3,
     )
     df_6_seasonal = make_data_file(
         unique_id="tasmin_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230", run=run3,
@@ -220,9 +228,11 @@ def populateddb(cleandb,):
         file2,
         file3,
         df_5_monthly,
+        df_5_monthly_online,
         df_5_seasonal,
         df_5_yearly,
         df_6_monthly,
+        df_6_monthly_online,
         df_6_seasonal,
         df_6_yearly,
         df_7_yearly,
@@ -313,9 +323,11 @@ def populateddb(cleandb,):
     tmax1 = make_data_file_variable(file2, var_name="tasmax",)
     tmax2 = make_data_file_variable(file3, var_name="tasmax",)
     tmax3 = make_data_file_variable(df_5_monthly, var_name="tasmax",)
+    tmax3_online = make_data_file_variable(df_5_monthly_online, var_name="tasmax",)
     tmax4 = make_data_file_variable(df_5_seasonal, var_name="tasmax",)
     tmax5 = make_data_file_variable(df_5_yearly, var_name="tasmax",)
     tmax6 = make_data_file_variable(df_6_monthly, var_name="tasmin",)
+    tmax6_online = make_data_file_variable(df_6_monthly_online, var_name="tasmin",)
     tmax7 = make_data_file_variable(df_6_seasonal, var_name="tasmin",)
     tmax8 = make_data_file_variable(df_6_yearly, var_name="tasmin",)
     pr1 = make_data_file_variable(df_7_yearly, var_name="pr",)
@@ -326,9 +338,11 @@ def populateddb(cleandb,):
         tmax1,
         tmax2,
         tmax3,
+        tmax3_online,
         tmax4,
         tmax5,
         tmax6,
+        tmax6_online,
         tmax7,
         tmax8,
         pr1,
@@ -383,6 +397,8 @@ def populateddb(cleandb,):
         file3,
         df_5_monthly,
         df_6_monthly,
+        df_5_monthly_online,
+        df_6_monthly_online,
     ]
 
     ts_seasonal = TimeSet(

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -893,3 +893,11 @@ polygons = {
 )
 def polygon(request,):
     return request.param
+
+
+@pytest.fixture
+def mock_thredds_url_root(monkeypatch):
+    monkeypatch.setenv(
+        "THREDDS_URL_ROOT",
+        "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
+    )

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -196,7 +196,8 @@ def populateddb(cleandb,):
         unique_id="tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", run=run3,
     )
     df_5_monthly_online = make_data_file(
-        unique_id="/storage/data/projects/comp_support/daccs/test-data/tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+        unique_id="tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+        filename="/storage/data/projects/comp_support/daccs/test-data/tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test.nc",
         run=run3,
     )
     df_5_seasonal = make_data_file(
@@ -209,7 +210,8 @@ def populateddb(cleandb,):
         unique_id="tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230", run=run3,
     )
     df_6_monthly_online = make_data_file(
-        unique_id="/storage/data/projects/comp_support/daccs/test-data/tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+        unique_id="tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test",
+        filename="/storage/data/projects/comp_support/daccs/test-data/tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230_test.nc",
         run=run3,
     )
     df_6_seasonal = make_data_file(

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,5 @@ env =
     REGION_DATA_DIRECTORY=ce/tests/data/regions
 
 markers =
+    online: marks tests that use an online resource (deselect with '-m "not online"')
     slow: marks tests that are slow (deselect with '-m "not slow"')


### PR DESCRIPTION
This allows `multistats/stats` to optionally target data from the `thredds` server. There is a bit of undesired manipulation that has to happen (namely copying the data to a `tempfile`) due to `rasterio`'s limitations.

Resolves #170.