### PR TITLE
Update "cell methods" parsing to support new Hydrology data

### DIFF
--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -11,7 +11,7 @@ from ce.api.util import (
     get_units_from_run_object,
     open_nc,
     check_final_cell_method,
-    is_valid_cell_method,
+    is_valid_cell_methods_param,
 )
 from distutils.util import strtobool
 
@@ -25,7 +25,7 @@ def data(
     variable,
     timescale="other",
     ensemble_name="ce_files",
-    cell_method="mean",
+    cell_methods="mean",
     is_thredds=False,
 ):
     """Delegate for performing data lookups across climatological files
@@ -57,7 +57,7 @@ def data(
 
         ensemble_name (str): Name of ensemble
 
-        cell_method (str): Statistical operation applied to variable in a
+        cell_methods (str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile). Defaulted to "mean".
 
@@ -118,8 +118,8 @@ def data(
         raise Exception(
             'time parameter "{}" not convertable to an integer.'.format(time)
         )
-    if not is_valid_cell_method(cell_method):
-        raise Exception("Unsupported cell_method: {}".format(cell_method))
+    if not is_valid_cell_methods_param(cell_methods):
+        raise Exception("Unsupported cell_methods parameter: {}".format(cell_methods))
 
     def get_spatially_averaged_data(data_file, time_idx, is_thredds):
         """
@@ -179,7 +179,7 @@ def data(
     data_file_variables = [
         dfv
         for dfv in data_file_variables
-        if check_final_cell_method(dfv.variable_cell_methods, cell_method, True)
+        if check_final_cell_method(dfv.variable_cell_methods, cell_methods, True)
     ]
 
     result = {}

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -6,7 +6,7 @@ import os
 
 from modelmeta import Run, Emission, Model, TimeSet, DataFile
 from modelmeta import DataFileVariableGridded, Ensemble
-from ce.api.util import get_array, get_units_from_run_object, open_nc
+from ce.api.util import get_array, get_units_from_run_object, open_nc, check_cell_method
 from distutils.util import strtobool
 
 
@@ -19,6 +19,7 @@ def data(
     variable,
     timescale="other",
     ensemble_name="ce_files",
+    cell_method="mean",
     is_thredds=False,
 ):
     """Delegate for performing data lookups across climatological files
@@ -49,6 +50,10 @@ def data(
             returned (e.g. "monthly" or "yearly")
 
         ensemble_name (str): Name of ensemble
+
+        cell_method (str): Statistical operation applied to variable in a
+            climatological dataset (e.g "mean", "standard_deviation",
+            "percentile). Defaulted to "mean".
 
         is_thredds (bool): If set to `True` the filepath will be searched for
             on THREDDS server. This flag is not needed when running the backend
@@ -162,8 +167,16 @@ def data(
     )
     data_file_variables = query.all()
 
+    # filter by cell methods parameter
+    data_file_variables = [
+        dfv
+        for dfv in data_file_variables
+        if check_cell_method(dfv.variable_cell_methods, cell_method, True)
+    ]
+
     result = {}
     for data_file_variable in data_file_variables:
+
         try:
             run_result = result[data_file_variable.file.run.name]
         except KeyError:

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -6,7 +6,13 @@ import os
 
 from modelmeta import Run, Emission, Model, TimeSet, DataFile
 from modelmeta import DataFileVariableGridded, Ensemble
-from ce.api.util import get_array, get_units_from_run_object, open_nc, check_cell_method
+from ce.api.util import (
+    get_array,
+    get_units_from_run_object,
+    open_nc,
+    check_final_cell_method,
+    is_valid_cell_method,
+)
 from distutils.util import strtobool
 
 
@@ -112,6 +118,8 @@ def data(
         raise Exception(
             'time parameter "{}" not convertable to an integer.'.format(time)
         )
+    if not is_valid_cell_method(cell_method):
+        raise Exception("Unsupported cell_method: {}".format(cell_method))
 
     def get_spatially_averaged_data(data_file, time_idx, is_thredds):
         """
@@ -171,7 +179,7 @@ def data(
     data_file_variables = [
         dfv
         for dfv in data_file_variables
-        if check_cell_method(dfv.variable_cell_methods, cell_method, True)
+        if check_final_cell_method(dfv.variable_cell_methods, cell_method, True)
     ]
 
     result = {}

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -14,7 +14,7 @@ def multistats(
     area=None,
     variable="",
     timescale="",
-    cell_method="mean",
+    cell_methods="mean",
     is_thredds=False,
 ):
     """Request and calculate statistics for multiple models or scenarios
@@ -50,7 +50,7 @@ def multistats(
         timescale (str): Description of the resolution of time to be
             returned (e.g. "monthly" or "yearly")
 
-        cell_method (str): Statistical operation applied to variable in a
+        cell_methods (str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile"). Defaulted to "mean".
 
@@ -96,6 +96,6 @@ def multistats(
     """
 
     ids = search_for_unique_ids(
-        sesh, ensemble_name, model, emission, variable, time, timescale, cell_method
+        sesh, ensemble_name, model, emission, variable, time, timescale, cell_methods
     )
     return {id_: stats(sesh, id_, time, area, variable, is_thredds)[id_] for id_ in ids}

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -51,8 +51,8 @@ def multistats(
             returned (e.g. "monthly" or "yearly")
 
         cell_method (str): Statistical operation applied to variable in a
-            climatological dataset (e.g "mean" or "standard_deviation").
-            Defaulted to "mean".
+            climatological dataset (e.g "mean", "standard_deviation",
+            "percentile"). Defaulted to "mean".
 
         is_thredds (bool): If set to `True` the filepath will be searched for
             on THREDDS server. This flag is not needed when running the backend

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -110,12 +110,12 @@ def mean_datetime(datetimes):
 
 
 # valid cell method parameters for the API. Add new ones here as needed.
-VALID_CELL_METHOD_PARAMETERS = ("mean", "standard_deviation", "percentile")
+VALID_CELL_METHODS_PARAMETERS = ("mean", "standard_deviation", "percentile")
 
 
-def is_valid_cell_method(cell_method):
+def is_valid_cell_methods_param(cell_methods):
     """Validate the cell_method parameter supplied by caller"""
-    return cell_method in VALID_CELL_METHOD_PARAMETERS
+    return cell_methods in VALID_CELL_METHODS_PARAMETERS
 
 
 def check_final_cell_method(cell_methods, target_method, default_to_mean=True):
@@ -129,7 +129,7 @@ def check_final_cell_method(cell_methods, target_method, default_to_mean=True):
     parsed = parse(cell_methods)
     if target_method == "mean" and default_to_mean:
         # determine means by process of elimination
-        nonmeans = [m for m in VALID_CELL_METHOD_PARAMETERS if m != "mean"]
+        nonmeans = [m for m in VALID_CELL_METHODS_PARAMETERS if m != "mean"]
         return parsed is None or parsed[-1].method.name not in nonmeans
     elif parsed is not None:
         return parsed[-1].method.name == target_method
@@ -170,8 +170,8 @@ def search_for_unique_ids(
     timescale="",
     cell_method="mean",
 ):
-    if not is_valid_cell_method(cell_method):
-        raise Exception("Unsupported cell_method: {}".format(cell_method))
+    if not is_valid_cell_methods_param(cell_method):
+        raise Exception("Unsupported cell_methods parameter: {}".format(cell_method))
 
     cell_methods = (
         sesh.query(mm.DataFileVariableGridded.variable_cell_methods)

--- a/ce/tests/api/test_data.py
+++ b/ce/tests/api/test_data.py
@@ -22,7 +22,9 @@ def test_data_bad_time(populateddb):
 
 
 @pytest.mark.online
-@pytest.mark.parametrize("variable", ("tasmax", "tasmin",))
+@pytest.mark.parametrize(
+    "variable,cell_method", (("tasmax", "standard_deviation"), ("tasmin", "mean"),)
+)
 @pytest.mark.parametrize(
     "timescale, time_idx, expected_ymd",
     (
@@ -32,7 +34,13 @@ def test_data_bad_time(populateddb):
     ),
 )
 def test_data_single_file(
-    populateddb, mock_thredds_url_root, variable, timescale, time_idx, expected_ymd
+    populateddb,
+    mock_thredds_url_root,
+    variable,
+    cell_method,
+    timescale,
+    time_idx,
+    expected_ymd,
 ):
     rv = data(
         populateddb.session,
@@ -43,6 +51,7 @@ def test_data_single_file(
         timescale=timescale,
         time=time_idx,
         ensemble_name="ce",
+        cell_method=cell_method,
     )
 
     assert len(rv) == 1

--- a/ce/tests/api/test_data.py
+++ b/ce/tests/api/test_data.py
@@ -23,7 +23,7 @@ def test_data_bad_time(populateddb):
 
 @pytest.mark.online
 @pytest.mark.parametrize(
-    "variable,cell_method", (("tasmax", "standard_deviation"), ("tasmin", "mean"),)
+    "variable,cell_methods", (("tasmax", "standard_deviation"), ("tasmin", "mean"),)
 )
 @pytest.mark.parametrize(
     "timescale, time_idx, expected_ymd",
@@ -37,7 +37,7 @@ def test_data_single_file(
     populateddb,
     mock_thredds_url_root,
     variable,
-    cell_method,
+    cell_methods,
     timescale,
     time_idx,
     expected_ymd,
@@ -51,7 +51,7 @@ def test_data_single_file(
         timescale=timescale,
         time=time_idx,
         ensemble_name="ce",
-        cell_method=cell_method,
+        cell_methods=cell_methods,
     )
 
     assert len(rv) == 1

--- a/ce/tests/api/test_multistats.py
+++ b/ce/tests/api/test_multistats.py
@@ -7,14 +7,14 @@ from ce.api import multistats
     ("filters", "keys"),
     (
         (
-            {"variable": "tasmax", "cell_method": "standard_deviation"},
+            {"variable": "tasmax", "cell_methods": "standard_deviation"},
             ("CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc", "file2"),
         ),
         (
             {
                 "variable": "tasmax",
                 "model": "BNU-ESM",
-                "cell_method": "standard_deviation",
+                "cell_methods": "standard_deviation",
             },
             ["tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
@@ -22,16 +22,16 @@ from ce.api import multistats
             {
                 "variable": "tasmax",
                 "timescale": "seasonal",
-                "cell_method": "standard_deviation",
+                "cell_methods": "standard_deviation",
             },
             ["tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
         (
-            {"variable": "tasmin", "model": "BNU-ESM", "cell_method": "mean"},
+            {"variable": "tasmin", "model": "BNU-ESM", "cell_methods": "mean"},
             ["tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
         (
-            {"variable": "pr", "model": "BNU-ESM", "cell_method": "mean"},
+            {"variable": "pr", "model": "BNU-ESM", "cell_methods": "mean"},
             ["pr_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
     ),

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -553,6 +553,7 @@ def multitime_db(cleandb,):
             file=file_,
             variable_alias=tasmax,
             grid=anuspline_grid,
+            variable_cell_methods="time: maximum time: mean over days"
         )
         for file_ in files
     ]

--- a/ce/tests/conftest.py
+++ b/ce/tests/conftest.py
@@ -553,7 +553,7 @@ def multitime_db(cleandb,):
             file=file_,
             variable_alias=tasmax,
             grid=anuspline_grid,
-            variable_cell_methods="time: maximum time: mean over days"
+            variable_cell_methods="time: maximum time: mean over days",
         )
         for file_ in files
     ]

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -9,7 +9,7 @@ from numpy.ma import MaskedArray
 from dateutil.parser import parse
 from netCDF4 import Dataset
 
-from ce.api.util import get_array, mean_datetime, open_nc
+from ce.api.util import get_array, mean_datetime, open_nc, check_final_cell_method
 
 
 @pytest.fixture(
@@ -94,3 +94,176 @@ def test_open_nc_exception(bad_path):
         with open_nc(bad_path) as nc:
             # Test won't make it this far, but in case we do, let's fail the test
             assert False
+
+
+@pytest.mark.parametrize(
+    ("cell_methods", "target_method", "default_to_mean", "expected"),
+    (
+        # standard_deviation dataset
+        (
+            "time: minimum time: standard_deviation over days",
+            "standard_deviation",
+            True,
+            True,
+        ),
+        (
+            "time: minimum time: standard_deviation over days",
+            "standard_deviation",
+            False,
+            True,
+        ),
+        ("time: minimum time: standard_deviation over days", "mean", True, False),
+        ("time: minimum time: standard_deviation over days", "mean", False, False),
+        ("time: minimum time: standard_deviation over days", "percentile", True, False),
+        (
+            "time: minimum time: standard_deviation over days",
+            "percentile",
+            False,
+            False,
+        ),
+        # percentile dataset
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "standard_deviation",
+            True,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "standard_deviation",
+            False,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "percentile",
+            True,
+            True,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "percentile",
+            False,
+            True,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "mean",
+            True,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "mean",
+            False,
+            False,
+        ),
+        # mean dataset - climatology - strict
+        ("time: maximum time: mean over days", "standard_deviation", True, False),
+        ("time: maximum time: mean over days", "standard_deviation", False, False),
+        ("time: maximum time: mean over days", "mean", True, True),
+        ("time: maximum time: mean over days", "mean", False, True),
+        ("time: maximum time: mean over days", "percentile", True, False),
+        ("time: maximum time: mean over days", "percentile", False, False),
+        # mean dataset - ensemble mean - strict
+        (
+            "time: maximum time: mean over days models: mean",
+            "standard_deviation",
+            True,
+            False,
+        ),
+        (
+            "time: maximum time: mean over days models: mean",
+            "standard_deviation",
+            False,
+            False,
+        ),
+        ("time: maximum time: mean over days models: mean", "mean", True, True),
+        ("time: maximum time: mean over days models: mean", "mean", False, True),
+        ("time: maximum time: mean over days models: mean", "percentile", True, False),
+        ("time: maximum time: mean over days models: mean", "percentile", False, False),
+        # mean dataset - incorrect
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            "standard_deviation",
+            True,
+            False,
+        ),
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            "standard_deviation",
+            False,
+            False,
+        ),
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            "mean",
+            True,
+            True,
+        ),
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            "mean",
+            False,
+            False,
+        ),
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            "percentile",
+            True,
+            False,
+        ),
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            "percentile",
+            False,
+            False,
+        ),
+        # mean dataset - unparseable
+        ("unspecified", "standard_deviation", True, False),
+        ("unspecified", "standard_deviation", False, False),
+        ("unspecified", "mean", True, True),
+        ("unspecified", "mean", False, False),
+        ("unspecified", "percentile", True, False),
+        ("unspecified", "percentile", False, False),
+        # mean dataset - mean of stdevs (we don't have any data like this, but could be possible)
+        (
+            "time: standard_deviation over days time: mean over days",
+            "standard_deviation",
+            True,
+            False,
+        ),
+        (
+            "time: standard_deviation over days time: mean over days",
+            "standard_deviation",
+            False,
+            False,
+        ),
+        ("time: standard_deviation over days time: mean over days", "mean", True, True),
+        (
+            "time: standard_deviation over days time: mean over days",
+            "mean",
+            False,
+            True,
+        ),
+        (
+            "time: standard_deviation over days time: mean over days",
+            "percentile",
+            True,
+            False,
+        ),
+        (
+            "time: standard_deviation over days time: mean over days",
+            "percentile",
+            False,
+            False,
+        ),
+    ),
+)
+def test_check_final_cell_method(
+    cell_methods, target_method, default_to_mean, expected
+):
+    assert (
+        check_final_cell_method(cell_methods, target_method, default_to_mean)
+        == expected
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ GDAL~=3.0
 rasterio~=1.1
 sqlalchemy==1.3.17
 contexttimer==0.3.3
+cf-cell-methods==0.1.0
 
 # For documentation
 Sphinx==3.2.1


### PR DESCRIPTION
This PR enhances the back end's ability to filter datasets based on a "cell_method" parameter passed to the API by a user, to support some new datasets (model ensemble percentiles) from Hydrology. These parameters are used to request data from only a specific type of statistical dataset, either:

* climatological mean / model ensemble mean (param:  `mean` - the default, used by all current PCEX functionality)
* climatological standard deviation (param: `standard_deviation` - used by plan2adapt's rules engine)
* model ensemble percentile (param: `percentile` - will be used by new portal for the hydrology data)

The following changes were made:
1. switch from parsing cell methods strings with regexes to parsing them with the [cf-cell-methods parser](https://github.com/pacificclimate/cf-cell-methods), which will allow more flexible cell methods filtering in the future if we need it
2. Add `percentile` as a valid param to APIs
3. Add filtering on cell methods to the `data` API
4. Update tests

Resolves #175 