### PR TITLE
Speed up /data API

### DIFF
--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -191,7 +191,7 @@ def data(
             run_result = result[data_file_variable.file.run.name] = {
                 "data": {},
                 "units": get_units_from_run_object(
-                    data_file_variable.file.run, variable, ensemble_name
+                    sesh, data_file_variable.file.run, variable, ensemble_name
                 ),
                 "modtime": data_file_variable.file.index_time,
             }

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -45,10 +45,12 @@ def get_units_from_run_object(sesh, run, varname, ensemble_name):
         .filter(mm.DataFileVariableGridded.netcdf_variable_name == varname)
         .filter(mm.Run.name == run.name)
     )
-    
+
     if len(units.all()) != 1:
         raise Exception(
-            "Run {} for variable {} does not have consistent units {}".format(run, varname, units.all())
+            "Run {} for variable {} does not have consistent units {}".format(
+                run, varname, units.all()
+            )
         )
 
     return units.scalar()

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -30,25 +30,28 @@ def get_units_from_netcdf_file(nc, variable):
     return nc.variables[variable].units
 
 
-def get_units_from_file_object(file_, varname):
-    for dfv in file_.data_file_variables:
-        if dfv.netcdf_variable_name == varname:
-            return dfv.variable_alias.units
-    raise Exception(
-        "Variable {} is not indexed for file {}".format(varname, file_.filename)
+def get_units_from_run_object(sesh, run, varname, ensemble_name):
+    units = (
+        sesh.query(mm.VariableAlias.units)
+        .distinct(mm.VariableAlias.units)
+        .join(
+            mm.DataFileVariableGridded,
+            mm.EnsembleDataFileVariables,
+            mm.Ensemble,
+            mm.DataFile,
+            mm.Run,
+        )
+        .filter(mm.Ensemble.name == ensemble_name)
+        .filter(mm.DataFileVariableGridded.netcdf_variable_name == varname)
+        .filter(mm.Run.name == run.name)
     )
-
-
-def get_units_from_run_object(run, varname, ensemble_name):
-    files = get_files_from_run_variable(run, varname, ensemble_name)
-    units = {get_units_from_file_object(file_, varname) for file_ in files}
-
-    if len(units) != 1:
+    
+    if len(units.all()) != 1:
         raise Exception(
-            "File list {} does not have consistent units {}".format(run.files, units)
+            "Run {} for variable {} does not have consistent units {}".format(run, varname, units.all())
         )
 
-    return units.pop()
+    return units.scalar()
 
 
 def get_grid_from_netcdf_file(nc):
@@ -162,7 +165,7 @@ def filter_by_cell_method(cell_methods, target_method):
 
 def search_for_unique_ids(
     sesh,
-    ensemble_name="ce",
+    ensemble_name="ce_files",
     model="",
     emission="",
     variable="",

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -9,10 +9,15 @@ from numpy.ma import MaskedArray
 from dateutil.parser import parse
 from netCDF4 import Dataset
 
-from ce.api.util import get_array, mean_datetime, open_nc, check_final_cell_method, get_units_from_run_object
+from ce.api.util import (
+    get_array,
+    mean_datetime,
+    open_nc,
+    check_final_cell_method,
+    get_units_from_run_object,
+)
 
 from modelmeta.v2 import Run
-
 
 
 @pytest.fixture(
@@ -98,6 +103,7 @@ def test_open_nc_exception(bad_path):
             # Test won't make it this far, but in case we do, let's fail the test
             assert False
 
+
 @pytest.mark.parametrize(
     ("run_name", "var_name", "ensemble_name", "expected_units"),
     [
@@ -106,10 +112,12 @@ def test_open_nc_exception(bad_path):
         ("r1i1p1", "pr", "ce", "kg d-1 m-2"),
     ],
 )
-def test_get_units_from_run_object(populateddb, run_name, var_name, ensemble_name, expected_units):
+def test_get_units_from_run_object(
+    populateddb, run_name, var_name, ensemble_name, expected_units
+):
     run_object = Run(name=run_name)
     units = get_units_from_run_object(populateddb.session, Run, var_name, ensemble_name)
-    assert(units == expected_units)
+    assert units == expected_units
 
 
 @pytest.mark.parametrize(

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -9,7 +9,10 @@ from numpy.ma import MaskedArray
 from dateutil.parser import parse
 from netCDF4 import Dataset
 
-from ce.api.util import get_array, mean_datetime, open_nc, check_final_cell_method
+from ce.api.util import get_array, mean_datetime, open_nc, check_final_cell_method, get_units_from_run_object
+
+from modelmeta.v2 import Run
+
 
 
 @pytest.fixture(
@@ -94,6 +97,19 @@ def test_open_nc_exception(bad_path):
         with open_nc(bad_path) as nc:
             # Test won't make it this far, but in case we do, let's fail the test
             assert False
+
+@pytest.mark.parametrize(
+    ("run_name", "var_name", "ensemble_name", "expected_units"),
+    [
+        ("run1", "tasmax", "ce", "degC"),
+        ("r1i1p1", "tasmin", "ce", "degC"),
+        ("r1i1p1", "pr", "ce", "kg d-1 m-2"),
+    ],
+)
+def test_get_units_from_run_object(populateddb, run_name, var_name, ensemble_name, expected_units):
+    run_object = Run(name=run_name)
+    units = get_units_from_run_object(populateddb.session, Run, var_name, ensemble_name)
+    assert(units == expected_units)
 
 
 @pytest.mark.parametrize(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-SQLAlchemy
 Flask-Cors
 modelmeta==1.0.0
 shapely>=1.6
-numpy
+numpy~=1.20
 netCDF4==1.5.*
 GDAL~=3.0
 rasterio~=1.1


### PR DESCRIPTION
This PR speeds up the `/data` query by  streamlining `get_units_from_run_object()`.

`get_units_from_run_object()` checks all datasets associated with a particular run and variable to make sure they all have the same units and can be aggregated. Previously, the units were checked incrementally by getting the units from each datafile and comparing them. The rewritten function instead gets a list of all units at once from the database.

Timing information:
| Branch      | time to complete sample /data call |
|-------------|------------------------------------|
| [3.1.0](http://docker-dev01.pcic.uvic.ca:30399/api/data?ensemble_name=ce_files&model=CNRM-CM5&variable=fdd&emission=historical,rcp85&timescale=yearly&time=0&area=)       | 1.372 seconds                      |
| [3.2.0](http://docker-dev01.pcic.uvic.ca:30400/api/data?ensemble_name=ce_files&model=CNRM-CM5&variable=fdd&emission=historical,rcp85&timescale=yearly&time=0&area=)       | 22.135 seconds                     |
| [3.3.0](http://docker-dev01.pcic.uvic.ca:30401/api/data?ensemble_name=ce_files&model=CNRM-CM5&variable=fdd&emission=historical,rcp85&timescale=yearly&time=0&area=)       | 21.860 seconds                     |
| [this branch](http://docker-dev01.pcic.uvic.ca:30402/api/data?ensemble_name=ce_files&model=CNRM-CM5&variable=fdd&emission=historical,rcp85&timescale=yearly&time=0&area=) | 0.509 seconds                      |