### PR TITLE
Add filtering on cell_methods to multimeta API

### DIFF
--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -110,7 +110,7 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras="", cell_methods=
         q = q.filter(Model.short_name == model)
 
     results = q.all()
-    
+
     # filter by cell methods parameter
     results = [
         dataset

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -25,7 +25,7 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras="", cell_methods=
     Args:
         sesh (sqlalchemy.orm.session.Session): A database Session object
 
-        ensemble (str): Some named ensemble
+        ensemble_name (str): Some named ensemble
 
         model (str): Short name for some climate model (e.g "CGCM3")
 

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -84,7 +84,12 @@ from test_utils import check_dict_subset
         ),
         (
             "multimeta",
-            {"ensemble_name": "ce", "model": "", "extras": "filepath", "cell_methods": "standard_deviation"},
+            {
+                "ensemble_name": "ce",
+                "model": "",
+                "extras": "filepath",
+                "cell_methods": "standard_deviation",
+            },
             {
                 "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
                     "filepath": re.compile(

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -67,7 +67,7 @@ from test_utils import check_dict_subset
         ),
         (
             "multimeta",
-            {"ensemble_name": "ce", "model": ""},
+            {"ensemble_name": "ce", "model": "", "cell_methods": "standard_deviation"},
             {
                 "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
                     "institution": "CCCMA",
@@ -84,7 +84,7 @@ from test_utils import check_dict_subset
         ),
         (
             "multimeta",
-            {"ensemble_name": "ce", "model": "", "extras": "filepath"},
+            {"ensemble_name": "ce", "model": "", "extras": "filepath", "cell_methods": "standard_deviation"},
             {
                 "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
                     "filepath": re.compile(

--- a/ce/tests/api/test_multimeta.py
+++ b/ce/tests/api/test_multimeta.py
@@ -6,17 +6,17 @@ from ce.api import multimeta
 
 @pytest.mark.parametrize("model", ("BNU-ESM", "",))
 @pytest.mark.parametrize(
-    "unique_id",
-    (
-        "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
-        "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
-    ),
+    "cell_methods,unique_id",
+    [
+        ("standard_deviation", "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"),
+        ("mean", "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"),
+    ],
 )
 @pytest.mark.parametrize("extras", (None, "", "filepath", "filepath,obviouslywrong"))
-def test_multimeta(populateddb, model, unique_id, extras):
+def test_multimeta(populateddb, model, cell_methods, unique_id, extras):
     sesh = populateddb.session
     # Multimeta is wrapped for caching. Call the wrapped function
-    rv = multimeta(sesh, ensemble_name="ce", model=model, extras=extras)
+    rv = multimeta(sesh, ensemble_name="ce", model=model, extras=extras, cell_methods=cell_methods)
     assert unique_id in rv
     file_metadata = rv[unique_id]
 

--- a/ce/tests/api/test_multimeta.py
+++ b/ce/tests/api/test_multimeta.py
@@ -8,7 +8,10 @@ from ce.api import multimeta
 @pytest.mark.parametrize(
     "cell_methods,unique_id",
     [
-        ("standard_deviation", "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"),
+        (
+            "standard_deviation",
+            "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+        ),
         ("mean", "tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"),
     ],
 )
@@ -16,7 +19,9 @@ from ce.api import multimeta
 def test_multimeta(populateddb, model, cell_methods, unique_id, extras):
     sesh = populateddb.session
     # Multimeta is wrapped for caching. Call the wrapped function
-    rv = multimeta(sesh, ensemble_name="ce", model=model, extras=extras, cell_methods=cell_methods)
+    rv = multimeta(
+        sesh, ensemble_name="ce", model=model, extras=extras, cell_methods=cell_methods
+    )
     assert unique_id in rv
     file_metadata = rv[unique_id]
 

--- a/ce/tests/api/test_regions.py
+++ b/ce/tests/api/test_regions.py
@@ -15,7 +15,7 @@ def test_stored_data(populateddb):
     # "stored data" CSV during testing as well.
     removed_id = "removed"
     current_id = "pr_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230"
-    outdated_id = "tasmax_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230"
+    outdated_id = "tasmin_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230"
     region_dir = os.getenv("REGION_DATA_DIRECTORY").rstrip("/")
     with open("{}/test_region.csv".format(region_dir), "w") as outfile:
         outcsv = DictWriter(outfile, fieldnames=["unique_id", "modtime"])


### PR DESCRIPTION
This is a companion PR to #176, which added the ability to specify a cell_methods parameter (either "mean", "percentile", or "standard_deviation") to the `/data` API in order to support displaying datasets that are percentiles of a model ensemble. (The `/multistats` API already had this capability.)

This PR adds the same capacity to the `/multimeta` API.