### PR TITLE
Add climatological_statistic attribute to multimeta

### DIFF
--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -10,8 +10,8 @@ from ce.api.util import (
     get_array,
     get_units_from_run_object,
     open_nc,
-    check_final_cell_method,
-    is_valid_cell_methods_param,
+    check_climatological_statistic,
+    is_valid_clim_stat_param,
 )
 from distutils.util import strtobool
 
@@ -25,7 +25,7 @@ def data(
     variable,
     timescale="other",
     ensemble_name="ce_files",
-    cell_methods="mean",
+    climatological_statistic="mean",
     is_thredds=False,
 ):
     """Delegate for performing data lookups across climatological files
@@ -57,7 +57,7 @@ def data(
 
         ensemble_name (str): Name of ensemble
 
-        cell_methods (str): Statistical operation applied to variable in a
+        climatological_statistic (str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile). Defaulted to "mean".
 
@@ -118,8 +118,12 @@ def data(
         raise Exception(
             'time parameter "{}" not convertable to an integer.'.format(time)
         )
-    if not is_valid_cell_methods_param(cell_methods):
-        raise Exception("Unsupported cell_methods parameter: {}".format(cell_methods))
+    if not is_valid_clim_stat_param(climatological_statistic):
+        raise Exception(
+            "Unsupported climatological_statistic parameter: {}".format(
+                climatological_statistic
+            )
+        )
 
     def get_spatially_averaged_data(data_file, time_idx, is_thredds):
         """
@@ -179,7 +183,9 @@ def data(
     data_file_variables = [
         dfv
         for dfv in data_file_variables
-        if check_final_cell_method(dfv.variable_cell_methods, cell_methods, True)
+        if check_climatological_statistic(
+            dfv.variable_cell_methods, climatological_statistic, True
+        )
     ]
 
     result = {}

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -4,10 +4,12 @@
 from modelmeta import DataFile, Model, Emission, Run
 from modelmeta import DataFileVariableGridded, VariableAlias, TimeSet
 from modelmeta import EnsembleDataFileVariables, Ensemble
-from ce.api.util import check_final_cell_method, is_valid_cell_methods_param
+from ce.api.util import check_climatological_statistic, is_valid_clim_stat_param
 
 
-def multimeta(sesh, ensemble_name="ce_files", model="", extras="", cell_methods="mean"):
+def multimeta(
+    sesh, ensemble_name="ce_files", model="", extras="", climatological_statistic="mean"
+):
     """Retrieve metadata for all data files in an ensemble
 
     The ``multimeta`` API call is available to retrieve summarized
@@ -33,7 +35,7 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras="", cell_methods=
             response. Currently responds to fields:
                 "filepath": in each dictionary item, filepath of data file
 
-        cell_methods(str): Statistical operation applied to variable in a
+        climatological_statistic(str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile"). Defaulted to "mean".
 
@@ -69,8 +71,13 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras="", cell_methods=
 
     """
 
-    if not is_valid_cell_methods_param(cell_methods):
-        raise Exception("Unsupported cell_methods parameter: {}".format(cell_methods))
+    print("in multimeta!")
+    if not is_valid_clim_stat_param(climatological_statistic):
+        raise Exception(
+            "Unsupported climatological_statistic parameter: {}".format(
+                climatological_statistic
+            )
+        )
 
     q = (
         sesh.query(
@@ -115,8 +122,11 @@ def multimeta(sesh, ensemble_name="ce_files", model="", extras="", cell_methods=
     results = [
         dataset
         for dataset in results
-        if check_final_cell_method(dataset.cell_methods, cell_methods, True)
+        if check_climatological_statistic(
+            dataset.cell_methods, climatological_statistic, True
+        )
     ]
+    print("banana climatological statistic = {}".format(climatological_statistic))
 
     # FIXME: aggregation of the variables can be done in database with the
     # array_agg() function. Change this when SQLAlchemy supports it

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -4,7 +4,11 @@
 from modelmeta import DataFile, Model, Emission, Run
 from modelmeta import DataFileVariableGridded, VariableAlias, TimeSet
 from modelmeta import EnsembleDataFileVariables, Ensemble
-from ce.api.util import check_climatological_statistic, is_valid_clim_stat_param
+from ce.api.util import (
+    check_climatological_statistic,
+    is_valid_clim_stat_param,
+    get_climatological_statistic,
+)
 
 
 def multimeta(
@@ -126,7 +130,6 @@ def multimeta(
             dataset.cell_methods, climatological_statistic, True
         )
     ]
-    print("banana climatological statistic = {}".format(climatological_statistic))
 
     # FIXME: aggregation of the variables can be done in database with the
     # array_agg() function. Change this when SQLAlchemy supports it
@@ -169,5 +172,10 @@ def multimeta(
             result.netcdf_variable_name
         ] = result.variable_long_name
         rv[unique_id]["units"][result.netcdf_variable_name] = result.units
+        print("multi_year_mean = {}".format(result.multi_year_mean))
+        if result.multi_year_mean:
+            rv[unique_id]["climatological_statistic"] = get_climatological_statistic(
+                result.cell_methods
+            )
 
     return rv

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -75,7 +75,6 @@ def multimeta(
 
     """
 
-    print("in multimeta!")
     if not is_valid_clim_stat_param(climatological_statistic):
         raise Exception(
             "Unsupported climatological_statistic parameter: {}".format(
@@ -172,7 +171,6 @@ def multimeta(
             result.netcdf_variable_name
         ] = result.variable_long_name
         rv[unique_id]["units"][result.netcdf_variable_name] = result.units
-        print("multi_year_mean = {}".format(result.multi_year_mean))
         if result.multi_year_mean:
             rv[unique_id]["climatological_statistic"] = get_climatological_statistic(
                 result.cell_methods

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -14,7 +14,7 @@ def multistats(
     area=None,
     variable="",
     timescale="",
-    cell_methods="mean",
+    climatological_statistic="mean",
     is_thredds=False,
 ):
     """Request and calculate statistics for multiple models or scenarios
@@ -50,7 +50,7 @@ def multistats(
         timescale (str): Description of the resolution of time to be
             returned (e.g. "monthly" or "yearly")
 
-        cell_methods (str): Statistical operation applied to variable in a
+        climatological_statistic (str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile"). Defaulted to "mean".
 
@@ -96,6 +96,13 @@ def multistats(
     """
 
     ids = search_for_unique_ids(
-        sesh, ensemble_name, model, emission, variable, time, timescale, cell_methods
+        sesh,
+        ensemble_name,
+        model,
+        emission,
+        variable,
+        time,
+        timescale,
+        climatological_statistic,
     )
     return {id_: stats(sesh, id_, time, area, variable, is_thredds)[id_] for id_ in ids}

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -146,6 +146,22 @@ def check_climatological_statistic(
         return False
 
 
+def get_climatological_statistic(cell_methods, default_to_mean=True):
+    """Given a cell_methods string, returns a description of the
+    statistical process used to make the climatology, currently either
+    'mean', 'standard_deviation', or 'percentile[number]'.
+    If default_to_mean is true, unparsable and unrecognizable cell
+    methods strings will be treated as means."""
+    climatological_statistic = False
+    for clim_stat in VALID_CLIM_STAT_PARAMETERS:
+        if check_climatological_statistic(cell_methods, clim_stat, default_to_mean):
+            climatological_statistic = clim_stat
+
+    #    if climatological_statistic == "percentile":
+
+    return climatological_statistic
+
+
 def filter_by_climatological_statistic(cell_methods, climatological_statistic):
     """
     There are multiple types of statistical data available to the backend

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -157,7 +157,13 @@ def get_climatological_statistic(cell_methods, default_to_mean=True):
         if check_climatological_statistic(cell_methods, clim_stat, default_to_mean):
             climatological_statistic = clim_stat
 
-    #    if climatological_statistic == "percentile":
+    # return percentile number, if relevant
+    if climatological_statistic == "percentile":
+        cm_parsed = parse(cell_methods)
+        percentile_num = cm_parsed[-1].method.params[0]
+        climatological_statistic = "{}[{}]".format(
+            climatological_statistic, percentile_num
+        )
 
     return climatological_statistic
 

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -114,36 +114,39 @@ def mean_datetime(datetimes):
     return datetime.fromtimestamp(mean, tz=timezone.utc)
 
 
-# valid cell method parameters for the API. Add new ones here as needed.
-VALID_CELL_METHODS_PARAMETERS = ("mean", "standard_deviation", "percentile")
+# valid climatological statistic method parameters for the API. Add new ones here as needed.
+VALID_CLIM_STAT_PARAMETERS = ("mean", "standard_deviation", "percentile")
 
 
-def is_valid_cell_methods_param(cell_methods):
-    """Validate the cell_method parameter supplied by caller"""
-    return cell_methods in VALID_CELL_METHODS_PARAMETERS
+def is_valid_clim_stat_param(climatological_statistic):
+    """Validate the climatological_statistic parameter supplied by caller"""
+    return climatological_statistic in VALID_CLIM_STAT_PARAMETERS
 
 
-def check_final_cell_method(cell_methods, target_method, default_to_mean=True):
+def check_climatological_statistic(
+    cell_methods, climatological_statistic, default_to_mean=True
+):
     """Determines whether the final method in a cell methods string
-    (corresponding to a statistical aggregation) matches the target.
+    (corresponding to a statistical aggregation) matches the target
+    climatological statistic.
     If default_to_mean is true, treats errors and unrecognized methods
     as though they are climatological means. This compensates for some
     noisy cell_methods attributes in our data, all of which are
     climatological means.
     """
     parsed = parse(cell_methods)
-    if target_method == "mean" and default_to_mean:
+    if climatological_statistic == "mean" and default_to_mean:
         # determine means by process of elimination
-        nonmeans = [m for m in VALID_CELL_METHODS_PARAMETERS if m != "mean"]
+        nonmeans = [m for m in VALID_CLIM_STAT_PARAMETERS if m != "mean"]
         return parsed is None or parsed[-1].method.name not in nonmeans
     elif parsed is not None:
-        return parsed[-1].method.name == target_method
+        return parsed[-1].method.name == climatological_statistic
     else:
         # unparsable cell methods string
         return False
 
 
-def filter_by_cell_method(cell_methods, target_method):
+def filter_by_climatological_statistic(cell_methods, climatological_statistic):
     """
     There are multiple types of statistical data available to the backend
     via the modelmeta database:
@@ -161,7 +164,9 @@ def filter_by_cell_method(cell_methods, target_method):
     """
 
     return [
-        cm for cm in cell_methods if check_final_cell_method(cm, target_method, True)
+        cm
+        for cm in cell_methods
+        if check_climatological_statistic(cm, climatological_statistic, True)
     ]
 
 
@@ -173,10 +178,14 @@ def search_for_unique_ids(
     variable="",
     time=0,
     timescale="",
-    cell_method="mean",
+    climatological_statistic="mean",
 ):
-    if not is_valid_cell_methods_param(cell_method):
-        raise Exception("Unsupported cell_methods parameter: {}".format(cell_method))
+    if not is_valid_clim_stat_param(climatological_statistic):
+        raise Exception(
+            "Unsupported climatological_statistic parameter: {}".format(
+                clmatological_statistic
+            )
+        )
 
     cell_methods = (
         sesh.query(mm.DataFileVariableGridded.variable_cell_methods)
@@ -184,8 +193,8 @@ def search_for_unique_ids(
         .all()
     )
 
-    matching_cell_methods = filter_by_cell_method(
-        [r[0] for r in cell_methods], cell_method
+    matching_cell_methods = filter_by_climatological_statistic(
+        [r[0] for r in cell_methods], climatological_statistic
     )
 
     query = (

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -67,7 +67,11 @@ from test_utils import check_dict_subset
         ),
         (
             "multimeta",
-            {"ensemble_name": "ce", "model": "", "cell_methods": "standard_deviation"},
+            {
+                "ensemble_name": "ce",
+                "model": "",
+                "climatological_statistic": "standard_deviation",
+            },
             {
                 "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {
                     "institution": "CCCMA",
@@ -88,7 +92,7 @@ from test_utils import check_dict_subset
                 "ensemble_name": "ce",
                 "model": "",
                 "extras": "filepath",
-                "cell_methods": "standard_deviation",
+                "climatological_statistic": "standard_deviation",
             },
             {
                 "CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc": {

--- a/ce/tests/api/test_data.py
+++ b/ce/tests/api/test_data.py
@@ -23,7 +23,8 @@ def test_data_bad_time(populateddb):
 
 @pytest.mark.online
 @pytest.mark.parametrize(
-    "variable,cell_methods", (("tasmax", "standard_deviation"), ("tasmin", "mean"),)
+    "variable,climatological_statistic",
+    (("tasmax", "standard_deviation"), ("tasmin", "mean"),),
 )
 @pytest.mark.parametrize(
     "timescale, time_idx, expected_ymd",
@@ -37,7 +38,7 @@ def test_data_single_file(
     populateddb,
     mock_thredds_url_root,
     variable,
-    cell_methods,
+    climatological_statistic,
     timescale,
     time_idx,
     expected_ymd,
@@ -51,7 +52,7 @@ def test_data_single_file(
         timescale=timescale,
         time=time_idx,
         ensemble_name="ce",
-        cell_methods=cell_methods,
+        climatological_statistic=climatological_statistic,
     )
 
     assert len(rv) == 1

--- a/ce/tests/api/test_multimeta.py
+++ b/ce/tests/api/test_multimeta.py
@@ -6,7 +6,7 @@ from ce.api import multimeta
 
 @pytest.mark.parametrize("model", ("BNU-ESM", "",))
 @pytest.mark.parametrize(
-    "cell_methods,unique_id",
+    "climatological_statistic,unique_id",
     [
         (
             "standard_deviation",
@@ -16,11 +16,15 @@ from ce.api import multimeta
     ],
 )
 @pytest.mark.parametrize("extras", (None, "", "filepath", "filepath,obviouslywrong"))
-def test_multimeta(populateddb, model, cell_methods, unique_id, extras):
+def test_multimeta(populateddb, model, climatological_statistic, unique_id, extras):
     sesh = populateddb.session
     # Multimeta is wrapped for caching. Call the wrapped function
     rv = multimeta(
-        sesh, ensemble_name="ce", model=model, extras=extras, cell_methods=cell_methods
+        sesh,
+        ensemble_name="ce",
+        model=model,
+        extras=extras,
+        climatological_statistic=climatological_statistic,
     )
     assert unique_id in rv
     file_metadata = rv[unique_id]

--- a/ce/tests/api/test_multimeta.py
+++ b/ce/tests/api/test_multimeta.py
@@ -42,6 +42,7 @@ def test_multimeta(populateddb, model, climatological_statistic, unique_id, extr
         "start_date",
         "end_date",
         "modtime",
+        "climatological_statistic",
     ]:
         assert key in file_metadata
 

--- a/ce/tests/api/test_multistats.py
+++ b/ce/tests/api/test_multistats.py
@@ -7,14 +7,14 @@ from ce.api import multistats
     ("filters", "keys"),
     (
         (
-            {"variable": "tasmax", "cell_methods": "standard_deviation"},
+            {"variable": "tasmax", "climatological_statistic": "standard_deviation"},
             ("CanESM2-rcp85-tasmax-r1i1p1-2010-2039.nc", "file2"),
         ),
         (
             {
                 "variable": "tasmax",
                 "model": "BNU-ESM",
-                "cell_methods": "standard_deviation",
+                "climatological_statistic": "standard_deviation",
             },
             ["tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
@@ -22,16 +22,20 @@ from ce.api import multistats
             {
                 "variable": "tasmax",
                 "timescale": "seasonal",
-                "cell_methods": "standard_deviation",
+                "climatological_statistic": "standard_deviation",
             },
             ["tasmax_sClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
         (
-            {"variable": "tasmin", "model": "BNU-ESM", "cell_methods": "mean"},
+            {
+                "variable": "tasmin",
+                "model": "BNU-ESM",
+                "climatological_statistic": "mean",
+            },
             ["tasmin_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
         (
-            {"variable": "pr", "model": "BNU-ESM", "cell_methods": "mean"},
+            {"variable": "pr", "model": "BNU-ESM", "climatological_statistic": "mean"},
             ["pr_aClim_BNU-ESM_historical_r1i1p1_19650101-19701230"],
         ),
     ),

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -312,12 +312,22 @@ def test_check_climatological_statistic(
         (
             "time: mean within days time: max over days time: mean over days models: percentile[5]",
             True,
-            "percentile",
+            "percentile[5.0]",
         ),
         (
             "time: mean within days time: max over days time: mean over days models: percentile[5]",
             False,
-            "percentile",
+            "percentile[5.0]",
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[95]",
+            True,
+            "percentile[95.0]",
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[95]",
+            False,
+            "percentile[95.0]",
         ),
         ("time: maximum time: mean over days", True, "mean",),
         ("time: maximum time: mean over days", False, "mean"),

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -14,6 +14,7 @@ from ce.api.util import (
     mean_datetime,
     open_nc,
     check_climatological_statistic,
+    get_climatological_statistic,
     get_units_from_run_object,
 )
 
@@ -284,7 +285,7 @@ def test_get_units_from_run_object(
         ),
     ),
 )
-def test_check_final_cell_method(
+def test_check_climatological_statistic(
     cell_methods, climatological_statistic, default_to_mean, expected
 ):
     assert (
@@ -293,3 +294,50 @@ def test_check_final_cell_method(
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("cell_methods", "default_to_mean", "expected"),
+    (
+        (
+            "time: minimum time: standard_deviation over days",
+            True,
+            "standard_deviation",
+        ),
+        (
+            "time: minimum time: standard_deviation over days",
+            False,
+            "standard_deviation",
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            True,
+            "percentile",
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            False,
+            "percentile",
+        ),
+        ("time: maximum time: mean over days", True, "mean",),
+        ("time: maximum time: mean over days", False, "mean"),
+        ("time: maximum time: mean over days models: mean", True, "mean",),
+        ("time: maximum time: mean over days models: mean", False, "mean",),
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            True,
+            "mean",
+        ),
+        (
+            "time: minimum within days time: count within years where > 25 C",
+            False,
+            False,
+        ),
+        ("unspecified", True, "mean",),
+        ("unspecified", False, False,),
+        ("time: standard_deviation over days time: mean over days", True, "mean",),
+        ("time: standard_deviation over days time: mean over days", False, "mean",),
+    ),
+)
+def test_get_climatological_statistic(cell_methods, default_to_mean, expected):
+    assert get_climatological_statistic(cell_methods, default_to_mean) == expected

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -13,7 +13,7 @@ from ce.api.util import (
     get_array,
     mean_datetime,
     open_nc,
-    check_final_cell_method,
+    check_climatological_statistic,
     get_units_from_run_object,
 )
 
@@ -121,7 +121,7 @@ def test_get_units_from_run_object(
 
 
 @pytest.mark.parametrize(
-    ("cell_methods", "target_method", "default_to_mean", "expected"),
+    ("cell_methods", "climatological_statistic", "default_to_mean", "expected"),
     (
         # standard_deviation dataset
         (
@@ -285,9 +285,11 @@ def test_get_units_from_run_object(
     ),
 )
 def test_check_final_cell_method(
-    cell_methods, target_method, default_to_mean, expected
+    cell_methods, climatological_statistic, default_to_mean, expected
 ):
     assert (
-        check_final_cell_method(cell_methods, target_method, default_to_mean)
+        check_climatological_statistic(
+            cell_methods, climatological_statistic, default_to_mean
+        )
         == expected
     )


### PR DESCRIPTION
The PR adds a a `climatological_statistic` attribute to the `multimeta` API for climatology datasets. This allows the front end to have access to metadata on whether a dataset is a climatological mean, climatological standard deviation, or climatological percentile, which the front end will use to decide how to display each dataset, and which datasets to request more informaion on. The backend determines which sort of climatology a dataset is by parsing the `cell_methods` attribute of the dataset. If the `cell_methods` attribute is unparsable, the dataset is assumed to be a climatological mean.


In addition, some extra changes were made for clarity. There is now a clear distinction in the code between `cell_methods`, which refers to the `cell_methods` attribute of a dataset, describing the entire life history of that dataset; and `climatological_statistic` which is an attribute of multi year climatological datasets describing the statistical operation used to aggregate the climatology, determined from the `cell_method` by somewhat fuzzy logic.

* Some APIs which provide data previously accepted a parameter called `cell_methods`, which allowed the caller to filter datasets from which information was returned based on what sort of climatological statistic those datasets represented. Those APIs (`data`, `multimeta`, and `multistats`) have had that parameter renamed from `cell_methods` to `climatological_statistic` for consistency and clarity. 
* Some functions in `util.py` have also been renamed from `cell_methods_XYZ()` to `climatological_statistic_XYZ()`. 

Resolves #184 