### PR TITLE
Allow filtering by Nth percentile in data,multimeta, and multistat

### DIFF
--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -112,18 +112,19 @@ def data(
             }
 
     Raises:
-        Exception: If `time` parameter cannot be converted to an integer
+        ValueError: If `time` or `percentile` parameters cannot be converted
+        to an integer, if climatological_statistic parameter is not recognized
 
     """
     # Validate arguments
     try:
         time = int(time)
     except ValueError:
-        raise Exception(
+        raise ValueError(
             'time parameter "{}" not convertable to an integer.'.format(time)
         )
     if not is_valid_clim_stat_param(climatological_statistic):
-        raise Exception(
+        raise ValueError(
             "Unsupported climatological_statistic parameter: {}".format(
                 climatological_statistic
             )
@@ -132,7 +133,7 @@ def data(
         try:
             percentile = float(percentile)
         except ValueError:
-            raise Exception(
+            raise ValueError(
                 "Percentile parameter {} not convertable to a number".format(percentile)
             )
     if climatological_statistic == "percentile" and not percentile:

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -12,7 +12,12 @@ from ce.api.util import (
 
 
 def multimeta(
-    sesh, ensemble_name="ce_files", model="", extras="", climatological_statistic="mean"
+    sesh,
+    ensemble_name="ce_files",
+    model="",
+    extras="",
+    climatological_statistic="mean",
+    percentile=None,
 ):
     """Retrieve metadata for all data files in an ensemble
 
@@ -42,6 +47,8 @@ def multimeta(
         climatological_statistic(str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile"). Defaulted to "mean".
+        
+        percentile(float): optionally, specify a a single percentile values to filter on.
 
     Returns:
         A dictionary keyed by unique_id for all unique_ids in the
@@ -75,12 +82,20 @@ def multimeta(
 
     """
 
+    # validate input parameters
     if not is_valid_clim_stat_param(climatological_statistic):
         raise Exception(
             "Unsupported climatological_statistic parameter: {}".format(
                 climatological_statistic
             )
         )
+    if percentile is not None:
+        try:
+            percentile = float(percentile)
+        except ValueError:
+            raise Exception(
+                "Percentile parameter {} not convertable to a number".format(percentile)
+            )
 
     q = (
         sesh.query(
@@ -126,7 +141,10 @@ def multimeta(
         dataset
         for dataset in results
         if check_climatological_statistic(
-            dataset.cell_methods, climatological_statistic, True
+            dataset.cell_methods,
+            climatological_statistic,
+            default_to_mean=True,
+            match_percentile=percentile,
         )
     ]
 

--- a/ce/api/multimeta.py
+++ b/ce/api/multimeta.py
@@ -84,7 +84,7 @@ def multimeta(
 
     # validate input parameters
     if not is_valid_clim_stat_param(climatological_statistic):
-        raise Exception(
+        raise ValueError(
             "Unsupported climatological_statistic parameter: {}".format(
                 climatological_statistic
             )
@@ -93,7 +93,7 @@ def multimeta(
         try:
             percentile = float(percentile)
         except ValueError:
-            raise Exception(
+            raise ValueError(
                 "Percentile parameter {} not convertable to a number".format(percentile)
             )
 

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -98,7 +98,7 @@ def multistats(
     # we don't want people requesting statistics on percentile datasets;
     # that would be meaningless.
     if climatological_statistic == "percentile":
-        raise Exceptions(
+        raise ValueError(
             "Statistical calculations are not meaningful on percentile datasets."
         )
 

--- a/ce/api/multistats.py
+++ b/ce/api/multistats.py
@@ -15,7 +15,6 @@ def multistats(
     variable="",
     timescale="",
     climatological_statistic="mean",
-    percentile=None,
     is_thredds=False,
 ):
     """Request and calculate statistics for multiple models or scenarios
@@ -54,10 +53,6 @@ def multistats(
         climatological_statistic (str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile"). Defaulted to "mean".
-            
-        percentile(float): the percentile value to filter on if the 
-            climatological_statistic is percentile. Required if climatological_statistic
-            is percentile.
 
         is_thredds (bool): If set to `True` the filepath will be searched for
             on THREDDS server. This flag is not needed when running the backend
@@ -100,21 +95,11 @@ def multistats(
             }
     """
 
-    # validate inputs
-    if percentile is not None:
-        try:
-            percentile = float(percentile)
-        except ValueError:
-            raise Exception(
-                "Percentile parameter {} not convertable to a number".format(percentile)
-            )
-    if climatological_statistic == "percentile" and not percentile:
-        raise Exception(
-            "Percentile parameters must be specified to access percentile data"
-        )
-    if climatological_statistic != "percentile" and percentile:
-        raise Exception(
-            "Percentile parameter is only meaningful for percentile climatologies"
+    # we don't want people requesting statistics on percentile datasets;
+    # that would be meaningless.
+    if climatological_statistic == "percentile":
+        raise Exceptions(
+            "Statistical calculations are not meaningful on percentile datasets."
         )
 
     ids = search_for_unique_ids(
@@ -126,6 +111,5 @@ def multistats(
         time,
         timescale,
         climatological_statistic,
-        percentile,
     )
     return {id_: stats(sesh, id_, time, area, variable, is_thredds)[id_] for id_ in ids}

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -88,7 +88,7 @@ def stats(
         results dict will be missing the 'units' and 'time' keys.
 
     Raises:
-        Exception: If `time` parameter cannot be converted to an integer
+        ValueError: If `time` parameter cannot be converted to an integer
 
     """
     # Validate arguments
@@ -96,7 +96,7 @@ def stats(
         try:
             time = int(time)
         except ValueError:
-            raise Exception(
+            raise ValueError(
                 'time parameter "{}" not convertable to an integer.'.format(time)
             )
     else:

--- a/ce/api/streamflow/watershed.py
+++ b/ce/api/streamflow/watershed.py
@@ -379,7 +379,7 @@ def compute_melton_ratio(
     melton_ratio = elev_delta / area_sqrt
     if melton_ratio.check("[]"):  # ensure dimensionlessness
         return melton_ratio.magnitude
-    raise Exception(
+    raise ValueError(
         "Area and elevation units are not compatible: {} and {}".format(
             elevation_units, area_units
         )

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -193,7 +193,9 @@ def get_climatological_statistic(cell_methods, default_to_mean=True):
     return climatological_statistic
 
 
-def filter_by_climatological_statistic(cell_methods, climatological_statistic):
+def filter_by_climatological_statistic(
+    cell_methods, climatological_statistic, match_percentile=None
+):
     """
     There are multiple types of statistical data available to the backend
     via the modelmeta database:
@@ -213,7 +215,12 @@ def filter_by_climatological_statistic(cell_methods, climatological_statistic):
     return [
         cm
         for cm in cell_methods
-        if check_climatological_statistic(cm, climatological_statistic, True)
+        if check_climatological_statistic(
+            cm,
+            climatological_statistic,
+            default_to_mean=True,
+            match_percentile=match_percentile,
+        )
     ]
 
 
@@ -226,6 +233,7 @@ def search_for_unique_ids(
     time=0,
     timescale="",
     climatological_statistic="mean",
+    percentile=None,
 ):
     if not is_valid_clim_stat_param(climatological_statistic):
         raise Exception(
@@ -241,7 +249,9 @@ def search_for_unique_ids(
     )
 
     matching_cell_methods = filter_by_climatological_statistic(
-        [r[0] for r in cell_methods], climatological_statistic
+        [r[0] for r in cell_methods],
+        climatological_statistic,
+        match_percentile=percentile,
     )
 
     query = (

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -233,12 +233,11 @@ def search_for_unique_ids(
     time=0,
     timescale="",
     climatological_statistic="mean",
-    percentile=None,
 ):
     if not is_valid_clim_stat_param(climatological_statistic):
         raise Exception(
             "Unsupported climatological_statistic parameter: {}".format(
-                clmatological_statistic
+                climatological_statistic
             )
         )
 
@@ -249,9 +248,7 @@ def search_for_unique_ids(
     )
 
     matching_cell_methods = filter_by_climatological_statistic(
-        [r[0] for r in cell_methods],
-        climatological_statistic,
-        match_percentile=percentile,
+        [r[0] for r in cell_methods], climatological_statistic,
     )
 
     query = (

--- a/ce/api/util.py
+++ b/ce/api/util.py
@@ -124,7 +124,7 @@ def is_valid_clim_stat_param(climatological_statistic):
 
 
 def check_climatological_statistic(
-    cell_methods, climatological_statistic, default_to_mean=True
+    cell_methods, climatological_statistic, default_to_mean=True, match_percentile=None
 ):
     """Determines whether the final method in a cell methods string
     (corresponding to a statistical aggregation) matches the target
@@ -133,14 +133,39 @@ def check_climatological_statistic(
     as though they are climatological means. This compensates for some
     noisy cell_methods attributes in our data, all of which are
     climatological means.
+    If a "match_percentile" float is supplied, will only return true for
+    percentile datasets that match that specific percentile. Otherwise
+    will return true for any percentile dataset. match_percentile is
+    ignored if climatological_statistic is not "percentile".
     """
+
+    def final_method(p):
+        """get the name of the final cell method, corresponding 
+        to climatological aggregation (usually)"""
+        return p[-1].method.name
+
+    def final_params(p):
+        """get the parameters of the final cell method, providing details
+        of the climatological aggregation (ie, percentile value)"""
+        return p[-1].method.params
+
     parsed = parse(cell_methods)
+
     if climatological_statistic == "mean" and default_to_mean:
         # determine means by process of elimination
         nonmeans = [m for m in VALID_CLIM_STAT_PARAMETERS if m != "mean"]
-        return parsed is None or parsed[-1].method.name not in nonmeans
+        return parsed is None or final_method(parsed) not in nonmeans
+    elif (
+        parsed is not None
+        and climatological_statistic == "percentile"
+        and match_percentile is not None
+    ):
+        return (
+            final_method(parsed) == "percentile"
+            and final_params(parsed)[0] == match_percentile
+        )
     elif parsed is not None:
-        return parsed[-1].method.name == climatological_statistic
+        return final_method(parsed) == climatological_statistic
     else:
         # unparsable cell methods string
         return False

--- a/ce/tests/test_util.py
+++ b/ce/tests/test_util.py
@@ -297,6 +297,95 @@ def test_check_climatological_statistic(
 
 
 @pytest.mark.parametrize(
+    ("cell_methods, climatological_statistic, match_percentile, expected"),
+    (
+        (
+            "time: minimum time: standard_deviation over days",
+            "standard_deviation",
+            None,
+            True,
+        ),
+        ("time: minimum time: standard_deviation over days", "percentile", None, False),
+        ("time: minimum time: standard_deviation over days", "percentile", 5, False),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "standard_deviation",
+            None,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "standard_deviation",
+            5,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "percentile",
+            None,
+            True,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "percentile",
+            5,
+            True,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[5]",
+            "percentile",
+            95,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[95]",
+            "standard_deviation",
+            None,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[95]",
+            "standard_deviation",
+            5,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[95]",
+            "percentile",
+            None,
+            True,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[95]",
+            "percentile",
+            5,
+            False,
+        ),
+        (
+            "time: mean within days time: max over days time: mean over days models: percentile[95]",
+            "percentile",
+            95,
+            True,
+        ),
+        ("time: minimum time: standard_deviation over days[5]", "percentile", 5, False),
+        ("time: minimum time: standard_deviation[5] over days", "percentile", 5, False),
+    ),
+)
+def test_check_climatological_statistic_percentiles(
+    cell_methods, climatological_statistic, match_percentile, expected
+):
+    assert (
+        check_climatological_statistic(
+            cell_methods,
+            climatological_statistic,
+            default_to_mean=True,
+            match_percentile=match_percentile,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
     ("cell_methods", "default_to_mean", "expected"),
     (
         (


### PR DESCRIPTION
This PR extends the `climatological_statistic` parameter, with which a user specifies whether they want data from climatological means, climatological standard deviations, or climatological percentiles.The new parameter is called `percentile` and allows a user to specify exactly _which_ percentile values they would like data or metadata from, 5th percentile, 50th percentile, etc. 

The new `percentile` parameter has been added to all the APIs where one selects multiple datasets by specifying a set of parameters that describe them: `multimeta`, `multistats`, and `data`. For `multistats` and `data`, the `percentile` parameter must be specified if the `climatological_statistics` is `percentile`. That is,  with these two APIs, you cannot merely filter to all percentile datasets, you must filter to a specific percentile value, such as 45th percentile datasets. For the `multimeta` API, the parameter is optional, you may request metadata on either 45th percentile datasets, or on all percentile datasets.

This change will allow the front end to select percentiles for graphing or display.

**Question for reviewers**
Three APIs, `multimeta`, `multistat`, and `data` currently support the `climatological_percentile` attribute. These APIs  have a caller describe the dataset(s) they are interested in as a collection of filtering parameters; the other APIs return data on a single datafile and require its `unique_id`.

I added the `percentile` parameter to all three of these APIs. My reasoning was that it was good to have the APIs have similar interfaces. However, I'm not sure about this decision and would like thee reviewer to weigh in. Here are the considerations:

1. a user can specify `climatological_statistic` as `percentile` to access data or metadata from all percentile datasets at once, if allowed. A user can additionally specify `percentile` as `5` to see only 5th percentile datasets.

1. the PCEX frontend needs the `multimeta` API to be able to return a list of all percentile datasets (this is how it learns what percentiles are available). It does not currently need the `multimeta` API to be able to provide a list of all 5th percentile datasets, but I could imagine this theoretically being useful sometime.

1. The PCEX frontend needs to be able to request a specific percentile from the `data` API. The `data` API cannot display data from multiple percentiles at once (doesn't fit in its "run" format).

1. The PCEX frontend does not need to be able to request either a specific percentiles or all percentiles from the `multistat` API, and furthermore, requesting standard deviation of a percentile dataset is kind of a mathematical mess and I don't think we'll ever want to do it.

Given that, which of the three APIs should I add the new `percentile` parameter to? `data` is the one we need. We could want `multimeta` someday. We'll probably never want it for `multistat` and I only put it there for consistency.