### PR TITLE
Use min and max elevation datasets to calculate the Melton ratio in watershed

### DIFF
--- a/ce/api/streamflow/watershed.py
+++ b/ce/api/streamflow/watershed.py
@@ -123,8 +123,8 @@ def worker(
     :param station_lonlat: (tuple) Location of drainage point, (lon, lat)
     :param flow_direction: (VicDataGrid) Flow direction grid
     :param elevation_mean: (VicDataGrid) Mean elevation per grid cell, used for hypsometry
-    :param elevation_max: Maximum elevation per grid cell, used for Melton Ratio
-    :param elevation_min: Minimum elevation per grid cell, used for Melton Ratio
+    :param elevation_max: (VicDataGrid) Maximum elevation per grid cell, used for Melton Ratio
+    :param elevation_min: (VicDataGrid) Minimum elevation per grid cell, used for Melton Ratio
     :param area: (VicDataGrid) Area grid
     :return: (dict) representation for JSON response object; see watershed() for details
     """

--- a/ce/geo_data_grid_2d/vic/__init__.py
+++ b/ce/geo_data_grid_2d/vic/__init__.py
@@ -67,11 +67,11 @@ class VicDataGrid(GeoDataGrid2D):
         """
 
         def is_int(value):
-            return math.isclose(value - round(value), 0)
+            return math.isclose(value - round(value), 0, abs_tol=0.0000001)
 
         return (
-            math.isclose(self.lon_step, other.lon_step)
-            and math.isclose(self.lat_step, other.lat_step)
+            math.isclose(abs(self.lon_step), abs(other.lon_step))
+            and math.isclose(abs(self.lat_step), abs(other.lat_step))
             and is_int((self.longitudes[0] - other.longitudes[0]) / self.lon_step)
             and is_int((self.latitudes[0] - other.latitudes[0]) / self.lat_step)
         )

--- a/ce/tests/api/streamflow/watershed/conftest.py
+++ b/ce/tests/api/streamflow/watershed/conftest.py
@@ -43,6 +43,30 @@ def elevation_1(longitudes_1, latitudes_1):
 
 
 @pytest.fixture
+def elevation_max_1(longitudes_1, latitudes_1):
+    return VicDataGrid(
+        longitudes=longitudes_1,  # len = 3
+        latitudes=latitudes_1,  # len = 4
+        values=np_array(
+            ((3.1, 4.1, 3.1), (2.1, 2.1, 3.1), (3.1, 1.1, 3.1), (0.1, 3.1, 2.1),)
+        ),
+        units="m",
+    )
+
+
+@pytest.fixture
+def elevation_min_1(longitudes_1, latitudes_1):
+    return VicDataGrid(
+        longitudes=longitudes_1,  # len = 3
+        latitudes=latitudes_1,  # len = 4
+        values=np_array(
+            ((2.9, 3.9, 2.9), (1.9, 1.9, 2.9), (2.9, 0.9, 2.9), (0, 2.9, 1.9),)
+        ),
+        units="m",
+    )
+
+
+@pytest.fixture
 def area_1(longitudes_1, latitudes_1):
     return VicDataGrid(
         longitudes=longitudes_1,  # len = 3

--- a/ce/tests/api/streamflow/watershed/test_watershed.py
+++ b/ce/tests/api/streamflow/watershed/test_watershed.py
@@ -10,7 +10,7 @@ from test_utils import check_dict_subset
             0.11,
             50.25,
             {
-                "elevation": {"units": "m", "minimum": 0, "maximum": 4},
+                "elevation": {"units": "m", "minimum": 0, "maximum": 4.1},
                 "area": {"units": "m^2", "value": 7},
                 "hypsometric_curve": {
                     "elevation_bin_start": 0,
@@ -20,7 +20,7 @@ from test_utils import check_dict_subset
                     "elevation_units": "m",
                     "area_units": "m^2",
                 },
-                "melton_ratio": {"units": "km/km", "value": 1.5118578920369088,},
+                "melton_ratio": {"units": "km/km", "value": 1.5496543393378315,},
                 "boundary": {
                     # TODO: more here
                     "type": "Feature",
@@ -38,7 +38,7 @@ from test_utils import check_dict_subset
             0.19,
             50.47,
             {
-                "elevation": {"units": "m", "minimum": 1, "maximum": 4},
+                "elevation": {"units": "m", "minimum": 0.9, "maximum": 4.1},
                 "area": {"units": "m^2", "value": 6},
                 "hypsometric_curve": {
                     "elevation_bin_start": 0,
@@ -48,7 +48,7 @@ from test_utils import check_dict_subset
                     "elevation_units": "m",
                     "area_units": "m^2",
                 },
-                "melton_ratio": {"units": "km/km", "value": 1.2247448713915892,},
+                "melton_ratio": {"units": "km/km", "value": 1.3063945294843617,},
                 "boundary": {
                     # TODO: more here
                     "type": "Feature",
@@ -66,7 +66,7 @@ from test_utils import check_dict_subset
             0.3,
             50.2,
             {
-                "elevation": {"units": "m", "minimum": 2, "maximum": 3},
+                "elevation": {"units": "m", "minimum": 1.9, "maximum": 3.1},
                 "area": {"units": "m^2", "value": 3},
                 "hypsometric_curve": {
                     "elevation_bin_start": 0,
@@ -76,7 +76,7 @@ from test_utils import check_dict_subset
                     "elevation_units": "m",
                     "area_units": "m^2",
                 },
-                "melton_ratio": {"units": "km/km", "value": 0.5773502691896258,},
+                "melton_ratio": {"units": "km/km", "value": 0.692820323027551,},
                 "boundary": {
                     # TODO: more here
                     "type": "Feature",
@@ -92,6 +92,22 @@ from test_utils import check_dict_subset
         ),
     ),
 )
-def test_worker(lon, lat, expected, flow_direction_1, elevation_1, area_1):
-    result = worker((lon, lat), flow_direction_1, elevation_1, area_1)
+def test_worker(
+    lon,
+    lat,
+    expected,
+    flow_direction_1,
+    elevation_1,
+    elevation_max_1,
+    elevation_min_1,
+    area_1,
+):
+    result = worker(
+        (lon, lat),
+        flow_direction_1,
+        elevation_mean=elevation_1,
+        elevation_max=elevation_max_1,
+        elevation_min=elevation_min_1,
+        area=area_1,
+    )
     check_dict_subset(expected, result)


### PR DESCRIPTION
**Motivation**
While testing the new Melton ratio code, @AreliaTW discovered that the results were consistently lower than expected in the Upper Fraser. 

She traced the issue to our elevation dataset. The elevation dataset we are using records the mean elevation of each grid cell. The mean elevation dataset has the same grid as the flow direction dataset, which facilitates this endpoint's calculations. First it determined the extent of a watershed using the flow direction dataset, then it can project that extent directly onto other datasets (elevation, area) with the same grid to do further calculations.

Unfortunately, this grid is too coarse to record the highs and lows in terrain needed to calculate the Melton ratio, which is determined by dividing the difference between the highest and lowest points in a watershed by the square root of the area of the watershed. Peaks and valleys are smoothed out by the coarseness of the elevation dataset. The results with the high resolutoin DEM Hydrology normally uses to calculate Melton ratios were much larger. As a test, Arelia did some experimental Melton ratio calculations with a coarse elevation dataset and saw similar (wrong) results to the API's calculations.

After some discussion of the best way to proceed without making the calculations way more complicated, Arelia made us two new datasets, one for elevation minimum and one for elevation maximum. Each one uses the same coarse grid as the existing datasets, but represents the single highest or lowest point within that grid square, according to Hydrology's higher-resolution DEM.

**Actual Change**
This PR updates the watershed API to calculate the Melton Ratio from the new elevation minimum and elevation maximum datasets instead of the existing elevation mean dataset used to calculate the hypsometry data.