### PR TITLE
Document watershed APIs

### DIFF
--- a/doc/source/api/api-index.rst
+++ b/doc/source/api/api-index.rst
@@ -18,4 +18,6 @@ API Documentation
    stats <stats-api>
    timeseries <timeseries-api>
    watershed <watershed-api>
+   watershed-streams <watershed-streams-api>
+   downstream <downstream-api>
    regions <regions-api>

--- a/doc/source/api/downstream-api-usage.md
+++ b/doc/source/api/downstream-api-usage.md
@@ -1,0 +1,1 @@
+This API endpoint provides a GeoJSON object representing the path taken by water flowing downstream from the selected point. This downstream path will terminate either at the ocean, or, in cases where only partial flow network data is available, at the edge of the available data. If the selected point is not within the dataset, a 404 Not Found error will be returned.

--- a/doc/source/api/downstream-api.rst
+++ b/doc/source/api/downstream-api.rst
@@ -1,0 +1,13 @@
+.. To update documentation on the downstream endpoint, update the docstring in the
+   code, or downstream-api-usage.md.
+
+
+streamflow/downstream
+====================
+.. mdinclude:: downstream-api-usage.md
+
+.. mdinclude:: sesh-not-needed.md
+
+------
+
+.. autofunction:: ce.api.downstream

--- a/doc/source/api/watershed-api-usage.md
+++ b/doc/source/api/watershed-api-usage.md
@@ -19,3 +19,11 @@ However, for small areas with steep topography, it is common to see some of the 
 Consider the most extreme case of `n = 2` cells that happen to be positioned at the edge of a steep sided valley. One cell is in the valley bottom with an average elevation of 100 m. The other is cell, just adjacent to it, mostly covers the highland above with an average elevation of 500 m. In a histogram with 100 m bin width, we'd see non-zero areas for the 100 m bin and the 500 m bin, but zero areas for the 200 m, 300 m, and 400 m elevation bins, and in the graph these would look like gaps.
 
 We can see a similar effect for other small values of `n > 2` in steep terrain too. Once `n` becomes large enough, then the likelihood of an elevation bin not having some cells is quite low and these gaps do not appear.
+
+## Melton Ratio
+
+The Melton Ratio (ratio of watershed relief to the square of the area) is used to characterize a location as being dominated by either flooding (Melton ratios <0.3) or debris flows (Melton ratios >0.6) (Wilford et al., 2004).
+
+The watershed API delineates a watershed boundary, or drainage polygon, based on a pour point of interest in combination with VIC-GL’s flow network. The drainage polygon is used to select the minimum and maximum elevations, compute the watershed relief and area.
+
+Watershed relief is defined as maximum elevation minus minimum elevation. Minimum and maximum elevations are extracted from the GMTED2010 7.5 arc-second DEM (Danielson and Gesch, 2011).

--- a/doc/source/api/watershed-api-usage.md
+++ b/doc/source/api/watershed-api-usage.md
@@ -16,14 +16,14 @@ For large areas of the earth and reasonably large elevation bins, we expect to s
 
 However, for small areas with steep topography, it is common to see some of the elevation bins between min and max elevation with zero area. This is not an error in either the computation or the data that feeds it. It is instead a product of the fact that `n` surface grid cells can represent at most `n` elevations.
 
-Consider the most extreme case of `n = 2` cells that happen to be positioned at the edge of a steep sided valley. One cell is in the valley bottom with an average elevation of 100 m. The other is cell, just adjacent to it, mostly covers the highland above with an average elevation of 500 m. In a histogram with 100 m bin width, we'd see non-zero areas for the 100 m bin and the 500 m bin, but zero areas for the 200 m, 300 m, and 400 m elevation bins, and in the graph these would look like gaps.
+Consider the most extreme case of `n = 2` cells that happen to be positioned at the edge of a steep sided valley. One cell is in the valley bottom with an average elevation of 100 m. The other cell, just adjacent to it, mostly covers the highland above with an average elevation of 500 m. In a histogram with 100 m bin width, we'd see non-zero areas for the 100 m bin and the 500 m bin, but zero areas for the 200 m, 300 m, and 400 m elevation bins, and in the graph these would look like gaps.
 
 We can see a similar effect for other small values of `n > 2` in steep terrain too. Once `n` becomes large enough, then the likelihood of an elevation bin not having some cells is quite low and these gaps do not appear.
 
 ## Melton Ratio
 
-The Melton Ratio (ratio of watershed relief to the square of the area) is used to characterize a location as being dominated by either flooding (Melton ratios <0.3) or debris flows (Melton ratios >0.6) (Wilford et al., 2004).
+The Melton Ratio (ratio of watershed relief to the square of the area) is used to characterize a location as being dominated by either flooding (Melton ratios < 0.3) or debris flows (Melton ratios > 0.6) (Wilford et al., 2004).
 
-The watershed API delineates a watershed boundary, or drainage polygon, based on a pour point of interest in combination with VIC-GL’s flow network. The drainage polygon is used to select the minimum and maximum elevations, compute the watershed relief and area.
+The watershed API delineates a watershed boundary, or drainage polygon, based on a selected point of interest, from which all upstream cells are determined with VIC-GL’s flow network. The drainage polygon is used to select the minimum and maximum elevations, compute the watershed relief and area.
 
 Watershed relief is defined as maximum elevation minus minimum elevation. Minimum and maximum elevations are extracted from the GMTED2010 7.5 arc-second DEM (Danielson and Gesch, 2011).

--- a/doc/source/api/watershed-streams-api-usage.md
+++ b/doc/source/api/watershed-streams-api-usage.md
@@ -1,0 +1,3 @@
+This API endpoint provides a GeoJSON multiline object representing stream network connectivity upstream of the selected point. It is intended to allow the network of streams that drains to a specific outlet to be visualized on a map. No data about the size of the streams is provided, and streams are approximated as straight line segments connecting the centers of grid cells.
+
+The resolution of the network is limited by the resolution of the grid used to calculate the network. Each grid cell is defined as draining into one specific other grid cell. If there are multiple small streams in a grid cell, or small creeks or culverts smaller than a single grid cell, the stream network object returned by this API will not represent them accurately.

--- a/doc/source/api/watershed-streams-api.rst
+++ b/doc/source/api/watershed-streams-api.rst
@@ -1,0 +1,13 @@
+.. To update documentation on the watershed-streams endpoint, update the docstring in the
+   code, or watershed-streams-api-usage.md.
+
+
+streamflow/watershed_streams
+====================
+.. mdinclude:: watershed-streams-api-usage.md
+
+.. mdinclude:: sesh-not-needed.md
+
+------
+
+.. autofunction:: ce.api.watershed_streams


### PR DESCRIPTION
Updates documentation around the streamflow APIs:

* adds documentation for the `downstream` and `watershed_streams` APIs (resolve #216)
* adds documention of the Melton ration provided by @AreliaTW  to the `watershed` API (resolves #193)

@AreliaTW also provided images illustrating the Melton Ratio, but I am not sure how to include them. I shortened her text slightly for the purposes of an API document - API users don't need to know how the files are organized on the backend.