### PR TITLE
Accept long WKT strings as request payloads

### DIFF
--- a/ce/api/__init__.py
+++ b/ce/api/__init__.py
@@ -104,8 +104,6 @@ def call(session, request_type, item=None):
         and "area" not in kwargs
     ):
         if request.data:
-            print("area_key detected")
-            print("data is {}".format(request.data.decode("utf-8")))
             kwargs["area"] = request.data.decode("utf-8")
         else:
             return Response(

--- a/ce/api/data.py
+++ b/ce/api/data.py
@@ -21,8 +21,8 @@ def data(
     model,
     emission,
     time,
-    area,
     variable,
+    area=None,
     timescale="other",
     ensemble_name="ce_files",
     climatological_statistic="mean",
@@ -61,9 +61,9 @@ def data(
         climatological_statistic (str): Statistical operation applied to variable in a
             climatological dataset (e.g "mean", "standard_deviation",
             "percentile). Defaulted to "mean".
-        
+
         percentile (float): if climatological_statistic is "percentile", specifies what
-            percentile value to use. A percentile value must be provided if the 
+            percentile value to use. A percentile value must be provided if the
             climatological_statistic is "percentile".
 
         is_thredds (bool): If set to `True` the filepath will be searched for

--- a/ce/api/stats.py
+++ b/ce/api/stats.py
@@ -26,7 +26,12 @@ na_array_stats = {
 
 
 def stats(
-    sesh, id_, time, area, variable, is_thredds=False,
+    sesh,
+    id_,
+    time,
+    variable,
+    area=None,
+    is_thredds=False,
 ):
     """Request and calculate summary statistics averaged across a region
 
@@ -133,7 +138,7 @@ def stats(
 
 def array_stats(array):
     """Return the min, max, mean, median, standard deviation and number
-       of cells of a 3d data grid (numpy.ma.MaskedArray)
+    of cells of a 3d data grid (numpy.ma.MaskedArray)
     """
     return {
         "min": np.min(array).item(),

--- a/ce/api/timeseries.py
+++ b/ce/api/timeseries.py
@@ -9,7 +9,7 @@ from modelmeta import DataFile
 from ce.api.util import get_array, get_units_from_netcdf_file, open_nc
 
 
-def timeseries(sesh, id_, area, variable):
+def timeseries(sesh, id_, variable, area=None):
     """Delegate for performing data lookups within a single file
 
     Opens the data file specified by the id_ parameter and returns the

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -180,3 +180,21 @@ def test_missing_query_param(test_client, cleandb, endpoint, missing_params):
 )
 def test_find_modtime(obj, expected):
     assert find_modtime(obj) == expected
+
+
+def test_area_payload(test_client, populateddb):
+    unique_id = "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230"
+    var = "tasmax"
+    polygon = """POLYGON((-265 65,-265 72,-276 72,-276 65,-265 65))"""
+    url = "/api/timeseries"
+
+    params_plain = {"id_": unique_id, "variable": var}
+    params_area = {"id_": unique_id, "variable": var, "area": polygon}
+    params_key = {"id_": unique_id, "variable": var, "area_key": "abcdef"}
+
+    no_area =  test_client.get(url, query_string=params_plain)
+    param_area = test_client.get(url, query_string=params_area)
+    payload_area = test_client.get(url, query_string=params_key, data=polygon)
+
+    assert param_area.data == payload_area.data
+    assert param_area.data != no_area.data

--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -140,7 +140,7 @@ def test_dates_are_formatted(test_client, populateddb):
     ("endpoint", "missing_params"),
     [
         ("/api/metadata", ["model_id"]),
-        ("/api/data", ("model", "emission", "time", "area", "variable")),
+        ("/api/data", ("model", "emission", "time", "variable")),
     ],
 )
 def test_missing_query_param(test_client, cleandb, endpoint, missing_params):

--- a/ce/tests/api/test_stats.py
+++ b/ce/tests/api/test_stats.py
@@ -31,7 +31,7 @@ def test_stats(
     populateddb, polygon, mock_thredds_url_root, unique_id, var_name, is_thredds
 ):
     sesh = populateddb.session
-    rv = stats(sesh, unique_id, None, polygon, var_name, is_thredds)
+    rv = stats(sesh, unique_id, None, var_name, polygon, is_thredds)
     statistics = rv[unique_id]
     for attr in ("min", "max", "mean", "median", "stdev"):
         value = statistics[attr]
@@ -59,7 +59,7 @@ def test_stats(
 def test_stats_bad_params(populateddb, unique_id, var):
     sesh = populateddb.session
 
-    rv = stats(sesh, unique_id, None, None, var)
+    rv = stats(sesh, unique_id, None, var, None)
     assert math.isnan(rv[unique_id]["max"])
     assert "time" not in rv[unique_id]
     assert "units" not in rv[unique_id]

--- a/ce/tests/api/test_timeseries.py
+++ b/ce/tests/api/test_timeseries.py
@@ -11,7 +11,7 @@ from ce.api import timeseries
 )
 def test_timeseries(populateddb, polygon, unique_id, var):
     sesh = populateddb.session
-    rv = timeseries(sesh, unique_id, polygon, var)
+    rv = timeseries(sesh, unique_id, var, polygon)
     for key in ("id", "data", "units"):
         assert key in rv
     assert rv["id"] == unique_id
@@ -49,7 +49,7 @@ def test_timeseries(populateddb, polygon, unique_id, var):
 def test_timeseries_annual_variation(populateddb, unique_id, var):
     sesh = populateddb.session
     poly = """POLYGON((-265 65,-265 74,-276 74,-276 65,-265 65))"""
-    rv = timeseries(sesh, unique_id, poly, var)
+    rv = timeseries(sesh, unique_id, var, poly)
     values = set([])
     for val in rv["data"].values():
         assert val not in values
@@ -72,7 +72,7 @@ def test_timeseries_bad_id(populateddb, unique_id):
 def test_timeseries_speed(populateddb, polygon, unique_id, var):
     sesh = populateddb.session
     t0 = time()
-    timeseries(sesh, unique_id, polygon, var)
+    timeseries(sesh, unique_id, var, polygon)
     t = time() - t0
     print(t)
     assert t < 3

--- a/doc/source/api/api-overview.md
+++ b/doc/source/api/api-overview.md
@@ -1,5 +1,7 @@
 Documentation for each API endpoint is automatically generated from the code and docstring for that API's main function and may not be entirely user-friendly. There are some minor differences between the internal workings of the API function and the process of querying them over the web.
 
+## Session Parameter
+
 The query URL is constructed from a base url ending in a slash, followed by the name of the endpoint, a question mark, and then one or more parameters of the form `attribute=value`, seperated by ampersands. Parameters supplied via query URL should be web-encoded so that they will be correctly parsed.
 
 The automatically generated API documentation describes a `sesh` (database session) argument to each API function. Database sessions are supplied by the query parser and does not need to be given in the query URL.
@@ -9,3 +11,9 @@ For example, the `multimeta` function has a signature of `ce.api.multimeta(sesh,
 The query URL `https://base_url/multimeta?ensemble_name=ce_files&model=CanESM2` calls the `multimeta` endpoint and supplies two arguments for the `multimeta` function: `ensemble_name` is "ce_files" and `model` is CanESM2. `sesh` is not supplied in the query URL.
 
 The API function return values are converted to JSON for the endpoint response.
+
+## Querying Complex Polygons
+
+Several APIs accept an `area` parameter, which is a WKT string describing a polygon representing the spatial extent of desired data. WKT strings that including many vetices and would result in a URL longer than the standard 4096 bytes may be queried by sending the string in the payload of a `GET` request and including a unique `area_key` parameter in the URL.
+
+It is best to simplify request polygons to the extent possible. The server may time out if asked to return data from a polygon of more than a hundred vertices.

--- a/doc/source/api/api-overview.md
+++ b/doc/source/api/api-overview.md
@@ -14,6 +14,8 @@ The API function return values are converted to JSON for the endpoint response.
 
 ## Querying Complex Polygons
 
-Several APIs accept an `area` parameter, which is a WKT string describing a polygon representing the spatial extent of desired data. WKT strings that including many vetices and would result in a URL longer than the standard 4096 bytes may be queried by sending the string in the payload of a `GET` request and including a unique `area_key` parameter in the URL.
+Several APIs accept an `area` parameter, which is a WKT string describing a polygon representing the spatial extent of desired data. If the WKT string includes so many vertices that the resulting URL exceeds the standard 4096 bytes, it can instead be sent in the payload of the GET request along with the sha1 hash of the WKT string as the `area_hash` parameter. Providing the hash ensures response caching works correctly.
+
+WKT strings that including many vetices and would result in a URL longer than the standard 4096 bytes may be queried by sending the string in the payload of a `GET` request and including a unique `area_key` parameter in the URL.
 
 It is best to simplify request polygons to the extent possible. The server may time out if asked to return data from a polygon of more than a hundred vertices.


### PR DESCRIPTION
Updates pre-API parameter parsing so that if the caller sends an `area_key` parameter and no `area` parameter, the parser will check the payload of the `GET` request, and if there is data there, treat it as if it were the `area` parameter. 

This is intended to support the complex polygons generated in Climate Explorer and SCIP by users selected "all grid cells upstream of this point". These polygons can be too long to fit in the unofficial "standard" URI length of 4096 bytes.