### PR TITLE
Accept POST requests

### DIFF
--- a/ce/tests/api/test_api_misc.py
+++ b/ce/tests/api/test_api_misc.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from json import loads
+from json import loads, dumps
 from dateutil.parser import parse
 import re
 import pytest
@@ -180,3 +180,47 @@ def test_missing_query_param(test_client, cleandb, endpoint, missing_params):
 )
 def test_find_modtime(obj, expected):
     assert find_modtime(obj) == expected
+
+@pytest.mark.parametrize(
+    ("endpoint", "params"),
+    [
+        ("/api/timeseries", 
+        {
+            "id_": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+            "area": "POLYGON((-265 65,-265 72,-276 72,-276 65,-265 65))",
+            "variable": "tasmax"
+        }),
+        ("/api/timeseries", 
+        {
+            "id_": "tasmax_mClim_BNU-ESM_historical_r1i1p1_19650101-19701230",
+            "area": "",
+            "variable": "tasmax"
+        }),
+        ("/api/data", 
+        {
+            "model": "BNU-ESM",
+            "emission": "historical",
+            "time": 0,
+            "variable": "tasmax",
+            "area": ""
+        }),
+        ("/api/data", 
+        {
+            "model": "BNU-ESM",
+            "emission": "historical",
+            "time": 0,
+            "variable": "tasmax",
+            "area": "POLYGON((-265 65,-265 72,-276 72,-276 65,-265 65))"
+        }),
+    ],
+)
+def test_post_request(test_client, populateddb, endpoint, params):
+    
+    get = test_client.get(endpoint, query_string = params)
+    post = test_client.post(endpoint, data=params)
+    
+    print(get.data)
+    
+    assert get.status_code == 200
+    assert post.status_code == 200
+    assert get.data == post.data

--- a/ce/views.py
+++ b/ce/views.py
@@ -7,7 +7,7 @@ def add_routes(app):
 
     db = SQLAlchemy(app)
 
-    @app.route("/api/<request_type>")
+    @app.route("/api/<request_type>", methods= ['GET', 'POST'])
     def api_request(*args, **kwargs):
         return ce.api.call(db.session, *args, **kwargs)
 

--- a/doc/source/api/api-overview.md
+++ b/doc/source/api/api-overview.md
@@ -2,10 +2,18 @@ Documentation for each API endpoint is automatically generated from the code and
 
 The query URL is constructed from a base url ending in a slash, followed by the name of the endpoint, a question mark, and then one or more parameters of the form `attribute=value`, seperated by ampersands. Parameters supplied via query URL should be web-encoded so that they will be correctly parsed.
 
+The API function return values are converted to JSON for the endpoint response.
+
+## Session Argument
 The automatically generated API documentation describes a `sesh` (database session) argument to each API function. Database sessions are supplied by the query parser and does not need to be given in the query URL.
 
 For example, the `multimeta` function has a signature of `ce.api.multimeta(sesh, ensemble_name='ce_files', model='')`
 
 The query URL `https://base_url/multimeta?ensemble_name=ce_files&model=CanESM2` calls the `multimeta` endpoint and supplies two arguments for the `multimeta` function: `ensemble_name` is "ce_files" and `model` is CanESM2. `sesh` is not supplied in the query URL.
 
-The API function return values are converted to JSON for the endpoint response.
+## Dealing with Long Area Arguments
+This API accepts both GET requests (parameters specified in the URL) and POST requests (parameters specified in the request body) and treats them identically. Clients should send GET requests whenever possible, to take advantage of caching.
+
+However, in some cases, the `area` parameter, which is a WKT string defining the spatial region data is requested for, may be too long to fit in a standard length (4096 characters) URL. In that case, clients may send the area (and all other parameters) in the body of a GET request.
+
+It is best to simplify the `area` parameter as much as reasonably possible; the API may time out when accessing data for regions defined with more than a hundred vertices.


### PR DESCRIPTION
Updates the backend to accept HTTP `POST` requests in addition to HTTP `GET`. This is a straightforward update thanks to Flask's handy `request.values` attribute, which contains all parameters supplied either in the URL of a `POST` or the body of a `GET`, allowing the request methods to be treated identically.

The goal here is to be able to accept longer `area` strings, especially from user-selected regions, such as when a user clicks on a point in a flow network to select all grid squares upstream of that point. One notable example of selecting an upstream area along the FRASER river results in an `area` string ten thousand characters long, too long to send in a URL.

resolves #227 