### PR TITLE
Bump to 3.6.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # News / Release Notes
 
+## 3.6.3
+**2024-Aug-07**
+
+- Fixes a transient build error (no PR). 
+
 ## 3.6.2
 **2024-Feb-13**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ce"
-version = "3.6.1"
+version = "3.6.3"
 description = "PCIC's Climate Explorer (CE)"
 authors = [
    "Rod Glover <rglover@uvic.ca>",


### PR DESCRIPTION
This release has no code changes written by us, but tests that began spontaneously failing in 3.6.2 are working again, so it is likely some library we use has changed. The release exists for the sole purpose of getting that library change into docker containers.