### PR TITLE
test branch for build changes #3

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+minor change to force a rebuild.


### PR DESCRIPTION
things tried in this branch:

**upgraded to python 3.9 in containers in hopes of getting a new numpy**
result: no change, still nonspecific error installing numpy 1.17

**upgraded to python 3.10 in the hopes of getting a new numpy**
result: error installing poetry

 **couldn't find any reason for poetry install error and eventually just make a token change for a rerun**
result: installed poetry correctly (yay!) but still trying to install numpy 1.17. However, this time there's a more detailed error: ModuleNotFoundError: No module named 'distutils.msvccompiler'

this error seems to be a result of too-new setuptools versions. It's possibly caused by the update to 3.10m but I will see if I can pin setuptools and fix it.