### PR TITLE
Update to python 3.10

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,17 +6,14 @@ jobs:
   test:
 
     runs-on: ubuntu-22.04
-    container: pcic/geospatial-python:python-310
+    container: pcic/geospatial-python:3.4.0
 
     steps:
     - uses: actions/checkout@v2
     - name: Install system dependencies
       run: |
-        apt-get update
-        apt-get install -yq libxml2-dev
-        apt-get install -yq libxslt-dev
-        apt-get install -yq libffi-dev
-        apt-get install -yq wget
+        apt-get update 
+        apt-get install -yq libxml2-dev libxslt-dev libffi-dev wget
 
     - name: Install poetry
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,14 +6,17 @@ jobs:
   test:
 
     runs-on: ubuntu-22.04
-    container: pcic/geospatial-python:3.3.0
+    container: pcic/geospatial-python:python-310
 
     steps:
     - uses: actions/checkout@v2
     - name: Install system dependencies
       run: |
-        apk upgrade
-        apk add libxml2-dev libxslt-dev libffi-dev
+        apt-get update
+        apt-get install -yq libxml2-dev
+        apt-get install -yq libxslt-dev
+        apt-get install -yq libffi-dev
+        apt-get install -yq wget
 
     - name: Install poetry
       run: |

--- a/ce/api/geo.py
+++ b/ce/api/geo.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from threading import RLock
 from contextlib import ContextDecorator, contextmanager
 import shutil
@@ -16,7 +16,7 @@ import os
 
 # From http://stackoverflow.com/a/30316760/597593
 from numbers import Number
-from collections import Set, Mapping, deque
+from collections.abc import Set, Mapping
 
 from tempfile import NamedTemporaryFile
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,11 +1,11 @@
-FROM pcic/geospatial-python:3.3.0
+FROM pcic/geospatial-python:python-310
 
 RUN mkdir /app
 ADD poetry.lock /app
 ADD pyproject.toml /app
 WORKDIR /app
 
-RUN apk add libffi-dev
+RUN apt-get install libffi-dev
 RUN wget -O - https://install.python-poetry.org | python3 -
 ENV PATH=/root/.local/bin:$PATH
 RUN poetry install --with=dev

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM pcic/geospatial-python:python-310
+FROM pcic/geospatial-python:3.4.0
 
 RUN mkdir /app
 ADD poetry.lock /app

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,12 +1,19 @@
 # Image with gdal 3.3.0
-FROM pcic/geospatial-python:3.3.0
+FROM pcic/geospatial-python:python-310
 
-RUN apk add postgresql-dev libxml2-dev libxslt-dev geos-dev
+RUN apt-get update
+# RUN apt list --installed
+# RUN apt-get install postgresql-dev
+RUN apt-get install libpq-dev
+RUN apt-get install libxml2-dev
+# RUN apt-get install libxslt-dev
+RUN apt-get install libgeos-dev
+RUN apt-get install wget
 
 ADD . /app
 WORKDIR /app
 
-RUN apk add libffi-dev
+RUN apt-get install libffi-dev
 RUN wget -O - https://install.python-poetry.org | python3 -
 ENV PATH=/root/.local/bin:$PATH
 RUN poetry install

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,19 +1,16 @@
 # Image with gdal 3.3.0
-FROM pcic/geospatial-python:python-310
+FROM pcic/geospatial-python:3.4.0
 
-RUN apt-get update
-# RUN apt list --installed
-# RUN apt-get install postgresql-dev
-RUN apt-get install libpq-dev
-RUN apt-get install libxml2-dev
-# RUN apt-get install libxslt-dev
-RUN apt-get install libgeos-dev
-RUN apt-get install wget
+RUN apt-get update && \
+    apt-get install libpq-dev \
+    libxml2-dev \
+    libgeos-dev \
+    libffi-dev \
+    wget
 
 ADD . /app
 WORKDIR /app
 
-RUN apt-get install libffi-dev
 RUN wget -O - https://install.python-poetry.org | python3 -
 ENV PATH=/root/.local/bin:$PATH
 RUN poetry install

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -2,7 +2,7 @@
 FROM pcic/geospatial-python:3.4.0
 
 RUN apt-get update && \
-    apt-get install libpq-dev \
+    apt-get install -yq libpq-dev \
     libxml2-dev \
     libgeos-dev \
     libffi-dev \


### PR DESCRIPTION
Switches to [a newer version of the geospatial-python docker](https://github.com/pacificclimate/docker-geospatial-python) to fix a couple issues with the build. The new docker has ubuntu 22.04 (was previously ubuntu 18.04), gdal 3.4 (was previously 2.3.1), and python 3.10 (was previously 3.8).

A couple updates to imports to bring the code into line with python 3.10.

[Demo](https://beehive.pacificclimate.org/scip/app/) of SCIP with this backend.

resolves #233 
resolves #243